### PR TITLE
1.5.0 move to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 Librarian-puppet is a bundler for your puppet infrastructure.  You can use
 librarian-puppet to manage the puppet modules your infrastructure depends on,
-whether the modules come from the [Puppet Forge](https://forge.puppetlabs.com/),
+whether the modules come from the [Puppet Forge](https://forge.puppet.com/),
 Git repositories or just a path.
 
 * Librarian-puppet can reuse the dependencies listed in your `Modulefile` or `metadata.json`
-* Forge modules can be installed from [Puppetlabs Forge](https://forge.puppetlabs.com/) or an internal Forge such as [Pulp](http://www.pulpproject.org/)
+* Forge modules can be installed from [Puppetlabs Forge](https://forge.puppet.com/) or an internal Forge such as [Pulp](http://www.pulpproject.org/)
 * Git modules can be installed from a branch, tag or specific commit, optionally using a path inside the repository
 * Modules can be installed from GitHub using tarballs, without needing Git installed
 * Modules can be installed from a filesystem path

--- a/features/examples/duplicated_dependencies/Puppetfile
+++ b/features/examples/duplicated_dependencies/Puppetfile
@@ -1,3 +1,3 @@
-forge 'http://forge.puppetlabs.com'
+forge 'https://forge.puppet.com'
 
 metadata

--- a/features/examples/duplicated_dependencies_transitive/Puppetfile
+++ b/features/examples/duplicated_dependencies_transitive/Puppetfile
@@ -1,4 +1,4 @@
-forge 'http://forge.puppetlabs.com'
+forge 'https://forge.puppet.com'
 
 metadata
 

--- a/features/examples/metadata_syntax/Puppetfile
+++ b/features/examples/metadata_syntax/Puppetfile
@@ -1,3 +1,3 @@
-forge 'http://forge.puppetlabs.com'
+forge 'https://forge.puppet.com'
 
 metadata

--- a/features/examples/modulefile_syntax/Puppetfile
+++ b/features/examples/modulefile_syntax/Puppetfile
@@ -1,3 +1,3 @@
-forge 'http://forge.puppetlabs.com'
+forge 'https://forge.puppet.com'
 
 modulefile

--- a/features/examples/with_puppetfile_and_metadata_json/Puppetfile
+++ b/features/examples/with_puppetfile_and_metadata_json/Puppetfile
@@ -1,3 +1,3 @@
-forge 'http://forge.puppetlabs.com'
+forge 'https://forge.puppet.com'
 
 mod 'maestrodev/test'

--- a/features/examples/with_puppetfile_and_modulefile/Puppetfile
+++ b/features/examples/with_puppetfile_and_modulefile/Puppetfile
@@ -1,3 +1,3 @@
-forge 'http://forge.puppetlabs.com'
+forge 'https://forge.puppet.com'
 
 mod 'maestrodev/test'

--- a/features/install.feature
+++ b/features/install.feature
@@ -19,7 +19,7 @@ Feature: cli/install
   Scenario: Install a module transitive dependency from git and forge should be deterministic
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/stdlib', :git => 'https://github.com/puppetlabs/puppetlabs-stdlib.git', :ref => '4.6.0'
     mod 'librarian/test', :git => 'https://github.com/rodjek/librarian-puppet.git', :path => 'features/examples/test'
@@ -32,7 +32,7 @@ Feature: cli/install
   Scenario: Install duplicated dependencies from git and forge, last one wins
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     metadata
     mod 'puppetlabs-stdlib', :git => 'https://github.com/puppetlabs/puppetlabs-stdlib.git', :ref => '4.6.0'
@@ -57,7 +57,7 @@ Feature: cli/install
   Scenario: Installing two modules with same name and using exclusions
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'librarian-duplicated_dependencies', :path => '../../features/examples/duplicated_dependencies'
     exclusion 'ripienaar-concat'
@@ -70,7 +70,7 @@ Feature: cli/install
   Scenario: Installing two modules with same name and using exclusions, apply transitively
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'librarian-duplicated_dependencies_transitive', :path => '../../features/examples/duplicated_dependencies_transitive'
     """
@@ -82,7 +82,7 @@ Feature: cli/install
   Scenario: Install a module with Modulefile without version
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'librarian-bad_modulefile', :path => 'bad_modulefile'
     """
@@ -101,7 +101,7 @@ Feature: cli/install
   Scenario: Install a module with the rsync configuration using the --clean flag
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'maestrodev/test'
     """
@@ -125,7 +125,7 @@ Feature: cli/install
   Scenario: Install a module with the rsync configuration using the --destructive flag
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'maestrodev/test'
     """
@@ -150,7 +150,7 @@ Feature: cli/install
   Scenario: Install a module with the rsync configuration
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'maestrodev/test'
     """

--- a/features/install/forge.feature
+++ b/features/install/forge.feature
@@ -55,7 +55,7 @@ Feature: cli/install/forge
   Scenario: Installing an exact version of a module
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/apt', '0.0.4'
     """
@@ -72,7 +72,7 @@ Feature: cli/install/forge
   Scenario: Installing a module in a path with spaces
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
     mod 'puppetlabs/stdlib', '4.1.0'
     """
     When PENDING I run `librarian-puppet install`
@@ -82,7 +82,7 @@ Feature: cli/install/forge
   Scenario: Installing a module with invalid versions in the forge
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/apache', '0.4.0'
     mod 'puppetlabs/postgresql', '2.0.1'
@@ -98,7 +98,7 @@ Feature: cli/install/forge
   Scenario: Installing a module with several constraints
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/apt', '>=1.0.0', '<1.0.1'
     """
@@ -112,7 +112,7 @@ Feature: cli/install/forge
     Given a directory named "puppet"
     And a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/ntp', '3.0.3'
     """
@@ -126,7 +126,7 @@ Feature: cli/install/forge
   Scenario: Handle range version numbers
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/postgresql', '3.2.0'
     mod 'puppetlabs/apt', '< 1.4.1' # 1.4.2 causes trouble in travis
@@ -138,7 +138,7 @@ Feature: cli/install/forge
 
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/postgresql', :git => 'git://github.com/puppetlabs/puppet-postgresql', :ref => '3.3.0'
     """
@@ -150,7 +150,7 @@ Feature: cli/install/forge
   Scenario: Installing a module that does not exist
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/xxxxx'
     """
@@ -164,7 +164,7 @@ Feature: cli/install/forge
   Scenario: Install a module with conflicts
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/apache', '0.6.0'
     mod 'puppetlabs/stdlib', '<2.2.1'
@@ -176,7 +176,7 @@ Feature: cli/install/forge
   Scenario: Install a module from the Forge with dependencies without version
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'sbadia/gitlab', '0.1.0'
     """
@@ -187,7 +187,7 @@ Feature: cli/install/forge
   Scenario: Source dependencies from Modulefile
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     modulefile
     """
@@ -203,7 +203,7 @@ Feature: cli/install/forge
   Scenario: Source dependencies from metadata.json
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     metadata
     """
@@ -226,7 +226,7 @@ Feature: cli/install/forge
   Scenario: Source dependencies from Modulefile using dash instead of slash
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     modulefile
     """
@@ -242,7 +242,7 @@ Feature: cli/install/forge
   Scenario: Installing a module with duplicated dependencies
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'pdxcat/collectd', '2.1.0'
     """
@@ -254,7 +254,7 @@ Feature: cli/install/forge
   Scenario: Installing two modules with same name, alphabetical order wins
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'ripienaar-concat', '0.2.0'
     mod 'puppetlabs-concat', '1.2.0'

--- a/features/install/git.feature
+++ b/features/install/git.feature
@@ -4,7 +4,7 @@ Feature: cli/install/git
   Scenario: Installing a module from git 
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/apache',
         :git => 'https://github.com/puppetlabs/puppetlabs-apache.git', :ref => '1.4.0'
@@ -34,7 +34,7 @@ Feature: cli/install/git
   Scenario: Installing a module with invalid versions in git
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod "apache",
       :git => "https://github.com/puppetlabs/puppetlabs-apache.git", :ref => "1.4.0"
@@ -47,7 +47,7 @@ Feature: cli/install/git
   Scenario: Switching a module from forge to git
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/postgresql', '4.0.0'
     """
@@ -58,7 +58,7 @@ Feature: cli/install/git
     And the file "modules/stdlib/metadata.json" should match /"name": "puppetlabs-stdlib"/
     When I overwrite "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/postgresql',
       :git => 'https://github.com/puppetlabs/puppetlabs-postgresql.git', :ref => '4.3.0'
@@ -113,7 +113,7 @@ Feature: cli/install/git
   Scenario: Running install with no Modulefile nor metadata.json
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/stdlib', :git => 'https://github.com/puppetlabs/puppetlabs-stdlib.git', :ref => '4.6.0'
     """
@@ -123,7 +123,7 @@ Feature: cli/install/git
   Scenario: Running install with metadata.json without dependencies
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/sqlite', :git => 'https://github.com/puppetlabs/puppetlabs-sqlite.git', :ref => '84a0a6'
     """
@@ -153,7 +153,7 @@ Feature: cli/install/git
   Scenario: Install a module from git and using path
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'librarian-test', :git => 'https://github.com/rodjek/librarian-puppet.git', :path => 'features/examples/test'
     """
@@ -165,7 +165,7 @@ Feature: cli/install/git
   Scenario: Install a module from git without version
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'test', :git => 'https://github.com/rodjek/librarian-puppet.git', :path => 'features/examples/dependency_without_version'
     """

--- a/features/install/github_tarball.feature
+++ b/features/install/github_tarball.feature
@@ -5,7 +5,7 @@ Feature: cli/install/github_tarball
   Scenario: Installing a module from github tarballs
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/apache', '0.6.0', :github_tarball => 'puppetlabs/puppetlabs-apache'
     mod 'puppetlabs/stdlib', '2.3.0', :github_tarball => 'puppetlabs/puppetlabs-stdlib'

--- a/features/install/path.feature
+++ b/features/install/path.feature
@@ -45,7 +45,7 @@ Feature: cli/install/path
   Scenario: Install a module from path without version
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'test', :path => '../../features/examples/dependency_without_version'
     """

--- a/features/outdated.feature
+++ b/features/outdated.feature
@@ -4,14 +4,14 @@ Feature: cli/outdated
   Scenario: Running outdated with forge modules
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/stdlib', '>=3.1.x'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forge.puppet.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -28,14 +28,14 @@ Feature: cli/outdated
   Scenario: Running outdated with git modules
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'test', :git => 'https://github.com/rodjek/librarian-puppet.git', :path => 'features/examples/test'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forge.puppet.com
       specs:
         puppetlabs/stdlib (3.1.0)
 

--- a/features/package.feature
+++ b/features/package.feature
@@ -4,7 +4,7 @@ Feature: cli/package
   Scenario: Packaging a forge module
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/apt', '1.4.0'
     mod 'puppetlabs/stdlib', '4.1.0'
@@ -20,7 +20,7 @@ Feature: cli/package
   Scenario: Packaging a git module
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/apt', '1.5.0', :git => 'https://github.com/puppetlabs/puppetlabs-apt.git', :ref => '1.5.0'
     mod 'puppetlabs/stdlib', '4.1.0'
@@ -37,7 +37,7 @@ Feature: cli/package
   Scenario: Packaging a github tarball module
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/apt', '1.4.0', :github_tarball => 'puppetlabs/puppetlabs-apt'
     mod 'puppetlabs/stdlib', '4.1.0'

--- a/features/update.feature
+++ b/features/update.feature
@@ -17,7 +17,7 @@ Feature: cli/update
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forge.puppet.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -40,7 +40,7 @@ Feature: cli/update
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forge.puppet.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -57,14 +57,14 @@ Feature: cli/update
   Scenario: Updating a module
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/stdlib', '3.1.x'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forge.puppet.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -80,14 +80,14 @@ Feature: cli/update
   Scenario: Updating a module using organization/module
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/stdlib', '3.1.x'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forge.puppet.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -103,7 +103,7 @@ Feature: cli/update
   Scenario: Updating a module from git with a branch ref
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod "puppetlabs-stdlib",
       :git => "https://github.com/puppetlabs/puppetlabs-stdlib.git", :ref => "3.2.x"
@@ -130,7 +130,7 @@ Feature: cli/update
   Scenario: Updating a module with invalid versions in git
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod "apache",
       :git => "https://github.com/puppetlabs/puppetlabs-apache.git", :ref => "0.5.0-rc1"
@@ -138,7 +138,7 @@ Feature: cli/update
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forge.puppet.com
       specs:
         puppetlabs/firewall (0.0.4)
         puppetlabs/stdlib (3.2.0)
@@ -164,14 +164,14 @@ Feature: cli/update
   Scenario: Updating a module that is not in the Puppetfile
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'puppetlabs/stdlib', '3.1.x'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forge.puppet.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -185,14 +185,14 @@ Feature: cli/update
   Scenario: Updating a module to a .10 release to ensure versions are correctly ordered
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'maestrodev/test'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forge.puppet.com
       specs:
         maestrodev/test (1.0.2)
 
@@ -208,14 +208,14 @@ Feature: cli/update
   Scenario: Updating a forge module with the rsync configuration
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod 'maestrodev/test'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forge.puppet.com
       specs:
         maestrodev/test (1.0.2)
 
@@ -243,7 +243,7 @@ Feature: cli/update
   Scenario: Updating a git module with the rsync configuration
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forge.puppet.com"
 
     mod "puppetlabs-stdlib",
       :git => "https://github.com/puppetlabs/puppetlabs-stdlib.git", :ref => "3.2.x"

--- a/lib/librarian/puppet/dsl.rb
+++ b/lib/librarian/puppet/dsl.rb
@@ -7,7 +7,7 @@ module Librarian
   module Puppet
     class Dsl < Librarian::Dsl
 
-      FORGE_URL = "http://forge.puppetlabs.com"
+      FORGE_URL = "https://forge.puppet.com"
 
       dependency :mod
 

--- a/lib/librarian/puppet/source/forge/repo.rb
+++ b/lib/librarian/puppet/source/forge/repo.rb
@@ -87,7 +87,7 @@ module Librarian
             target = vendored?(name, version) ? vendored_path(name, version).to_s : name
 
             # can't pass the default v3 forge url (http://forgeapi.puppetlabs.com)
-            # to clients that use the v1 API (https://forge.puppetlabs.com)
+            # to clients that use the v1 API (https://forge.puppet.com)
             # nor the other way around
             module_repository = source.to_s
 

--- a/lib/librarian/puppet/source/forge/repo_v1.rb
+++ b/lib/librarian/puppet/source/forge/repo_v1.rb
@@ -11,10 +11,10 @@ module Librarian
           def initialize(source, name)
             super(source, name)
             # API returned data for this module including all versions and dependencies, indexed by module name
-            # from http://forge.puppetlabs.com/api/v1/releases.json?module=#{name}
+            # from https://forge.puppet.com/api/v1/releases.json?module=#{name}
             @api_data = nil
             # API returned data for this module and a specific version, indexed by version
-            # from http://forge.puppetlabs.com/api/v1/releases.json?module=#{name}&version=#{version}
+            # from https://forge.puppet.com/api/v1/releases.json?module=#{name}&version=#{version}
             @api_version_data = {}
           end
 

--- a/librarian-puppet.gemspec
+++ b/librarian-puppet.gemspec
@@ -32,10 +32,16 @@ Gem::Specification.new do |s|
 
   # only needed for ruby 1.8
   s.add_dependency "json"
+  if RUBY_VERSION.to_f < 1.9
+    s.add_development_dependency "rake", '< 11'
+    s.add_development_dependency "cucumber", '~> 1.3.20'
+    ENV['PUPPET_VERSION'] ||= '3.8.7'
+  else
+    s.add_development_dependency "rake"
+    s.add_development_dependency "cucumber"
+  end
 
-  s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
-  s.add_development_dependency "cucumber"
   s.add_development_dependency "aruba"
   s.add_development_dependency "puppet", ENV["PUPPET_VERSION"]
   s.add_development_dependency "minitest", "~> 5"

--- a/spec/action/resolve_spec.rb
+++ b/spec/action/resolve_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require_relative '../../lib/librarian/puppet/action/resolve'
+require File.join(File.dirname(__FILE__),'../../lib/librarian/puppet/action/resolve')
 require 'librarian/ui'
 require 'thor'
 

--- a/spec/source/forge_repo_spec.rb
+++ b/spec/source/forge_repo_spec.rb
@@ -4,7 +4,7 @@ require "librarian/puppet/environment"
 describe Librarian::Puppet::Source::Forge::Repo do
 
   let(:environment) { Librarian::Puppet::Environment.new }
-  let(:uri) { "https://forge.puppetlabs.com" }
+  let(:uri) { "https://forge.puppet.com" }
   let(:source) { Librarian::Puppet::Source::Forge.new(environment, uri) }
   subject { Librarian::Puppet::Source::Forge::Repo.new(source, "puppetlabs/stdlib") }
 

--- a/spec/source/forge_spec.rb
+++ b/spec/source/forge_spec.rb
@@ -7,7 +7,7 @@ include Librarian::Puppet::Source
 describe Forge do
 
   let(:environment) { Librarian::Puppet::Environment.new }
-  let(:uri) { "https://forge.puppetlabs.com" }
+  let(:uri) { "https://forge.puppet.com" }
   let(:puppet_version) { "3.6.0" }
   subject { Forge.new(environment, uri) }
 


### PR DESCRIPTION
So this is #25 but for the 1.x branch, including fixes so that tests run on 1.8.

It would be great if we could that get merged and a 1.5.1 being released, so that people still have chance to move off 1.8 with proper testing. Because at the moment all testing is broken on 1.8, as moving to https triggers a runtime error of open:

```
home/travis/.rvm/rubies/ruby-1.8.7-p374/lib/ruby/1.8/open-uri.rb:174:in `open_loop': redirection forbidden: http://forge.puppetlabs.com/api/v1/releases.json?module=puppetlabs/stdlib -> https://forge.puppetlabs.com/api/v1/releases.json?module=puppetlabs/stdlib (RuntimeError)

    from /home/travis/.rvm/rubies/ruby-1.8.7-p374/lib/ruby/1.8/open-uri.rb:132:in `open_uri'
```

Please really consider this merging and releasing, although I'm fully aware of your dropping 1.8 policy, but the current enforcement to https just leaves people in progress migrating of 1.8 codebase (like me) totally in dark and it's quite frustrating not being able to test you new code targeted to move off of 1.8 for systems that are still stuck on 1.8. Not everybody has the luxury of rebuilding everything from scratch.
