### PR TITLE
Fix download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - '2.2'
   - '2.1'
   - '2.0'
-  - '1.9'
 notifications:
   email:
     - tim@github.com

--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -158,8 +158,18 @@ module Librarian
           @repo ||= {}
 
           unless @repo[name]
-            # if we are using the official Forge then use API v3, otherwise stick to v1 for now
-            if uri.hostname =~ /\.puppetlabs\.com$/ || !environment.use_v1_api
+            use_version_3 = true
+            # Use v3 of the api unless the url is the old one or v1 is explicitly set
+            if uri.hostname =~ /forge\.puppetlabs\.com$/ || environment.use_v1_api
+              use_version_3 = false
+            end
+
+            #Override the above if they have specified the forgeapi (v3) endpoint
+            if uri.hostname =~ /forgeapi\.puppetlabs\.com$/
+              use_version_3 = true
+            end
+
+            if use_version_3
               @repo[name] = RepoV3.new(self, name)
             else
               @repo[name] = RepoV1.new(self, name)

--- a/lib/librarian/puppet/source/forge/repo.rb
+++ b/lib/librarian/puppet/source/forge/repo.rb
@@ -32,9 +32,8 @@ module Librarian
             # implement in subclasses
           end
 
-          # return the url for a specific version tarball
-          # version: Librarian::Manifest::Version
-          def url(name, version)
+          # Download the module to the path specified
+          def download(name, version, path)
             # implement in subclasses
           end
 
@@ -73,46 +72,13 @@ module Librarian
             path = version_unpacked_cache_path(version)
             return if path.directory?
 
-            # The puppet module command is only available from puppet versions >= 2.7.13
-            #
-            # Specifying the version in the gemspec would force people to upgrade puppet while it's still usable for git
-            # So we do some more clever checking
-            #
-            # Executing older versions or via puppet-module tool gives an exit status = 0 .
-            #
-            check_puppet_module_options
-
             path.mkpath
 
-            target = vendored?(name, version) ? vendored_path(name, version).to_s : name
-
-            # can't pass the default v3 forge url (http://forgeapi.puppetlabs.com)
-            # to clients that use the v1 API (https://forge.puppetlabs.com)
-            # nor the other way around
-            module_repository = source.to_s
-
-            if Forge.client_api_version() > 1 and module_repository =~ %r{^http(s)?://forge\.puppetlabs\.com}
-              module_repository = "https://forgeapi.puppetlabs.com"
-              warn { "Replacing Puppet Forge API URL to use v3 #{module_repository} as required by your client version #{Librarian::Puppet.puppet_version}" }
-            end
-
-            m = module_repository.match(%r{^http(s)?://forge(api)?\.puppetlabs\.com})
-            if Forge.client_api_version() == 1 and m
-              ssl = m[1]
-              # Puppet 2.7 can't handle the 302 returned by the https url, so stick to http
-              if ssl and Librarian::Puppet::puppet_gem_version < Gem::Version.create('3.0.0')
-                warn { "Using plain http as your version of Puppet #{Librarian::Puppet::puppet_gem_version} can't download from forge.puppetlabs.com using https" }
-                ssl = nil
-              end
-              module_repository = "http#{ssl}://forge.puppetlabs.com"
-            end
-
-            command = %W{puppet module install --version #{version} --target-dir}
-            command.push(*[path.to_s, "--module_repository", module_repository, "--modulepath", path.to_s, "--module_working_dir", path.to_s, "--ignore-dependencies", target])
-            debug { "Executing puppet module install for #{name} #{version}: #{command.join(" ")}" }
+            download(name, version, "#{path.to_s}/#{name}-#{version}.tar.gz")
 
             begin
-              Librarian::Posix.run!(command)
+              Librarian::Posix.run!(%W{tar -xf #{path.to_s}/#{name}-#{version}.tar.gz -C #{path.to_s}})
+              FileUtils::mv "#{path.to_s}/#{name}-#{version}", "#{path.to_s}/#{name.split('-')[1]}"
             rescue Posix::CommandFailure => e
               # Rollback the directory if the puppet module had an error
               begin
@@ -126,29 +92,18 @@ module Librarian
                 file = tar.first
                 msg = " (looks like an incomplete download of #{file})"
               end
-              raise Error, "Error executing puppet module install#{msg}. Check that this command succeeds:\n#{command.join(" ")}\nError:\n#{e.message}"
+              raise Error, "Error extracting module #{msg}."
             end
 
           end
 
-          def check_puppet_module_options
-            min_version    = Gem::Version.create('2.7.13')
-
-            if Librarian::Puppet.puppet_gem_version < min_version
-              raise Error, "To get modules from the forge, we use the puppet faces module command. For this you need at least puppet version 2.7.13 and you have #{Librarian::Puppet.puppet_version}"
-            end
-          end
 
           def vendor_cache(name, version)
-            url = url(name, version)
             path = vendored_path(name, version).to_s
-            debug { "Downloading #{url} into #{path}"}
             environment.vendor!
-            File.open(path, 'wb') do |f|
-              open(url, "rb") do |input|
-                f.write(input.read)
-              end
-            end
+
+            download(name, version, path)
+
           end
 
         end

--- a/lib/librarian/puppet/source/forge/repo_v1.rb
+++ b/lib/librarian/puppet/source/forge/repo_v1.rb
@@ -26,11 +26,11 @@ module Librarian
             api_version_data(name, version)['dependencies']
           end
 
-          def download(name, version)
+          def download(name, version, path)
             info = api_version_data(name, version)
             url = "#{source}#{info[name].first['file']}"
 
-            debug { "Downloading #{release.download_url} into #{path}"}
+            debug { "Downloading #{url} into #{path}"}
             download_file(url, path)
           end
 

--- a/lib/librarian/puppet/source/forge/repo_v1.rb
+++ b/lib/librarian/puppet/source/forge/repo_v1.rb
@@ -26,9 +26,12 @@ module Librarian
             api_version_data(name, version)['dependencies']
           end
 
-          def url(name, version)
+          def download(name, version)
             info = api_version_data(name, version)
-            "#{source}#{info[name].first['file']}"
+            url = "#{source}#{info[name].first['file']}"
+
+            debug { "Downloading #{release.download_url} into #{path}"}
+            download_file(url, path)
           end
 
         private

--- a/lib/librarian/puppet/source/forge/repo_v3.rb
+++ b/lib/librarian/puppet/source/forge/repo_v3.rb
@@ -24,7 +24,7 @@ module Librarian
             Hash[*array.flatten(1)]
           end
 
-          def url(name, version)
+          def download(name, version, path)
             if name == "#{get_module().owner.username}/#{get_module().name}"
               release = get_release(version)
             else
@@ -32,7 +32,8 @@ module Librarian
               debug { "Looking up url for #{name}@#{version}" }
               release = PuppetForge::V3::Release.find("#{name}-#{version}")
             end
-            "#{source}#{release.file_uri}"
+            debug { "Downloading #{release.download_url} into #{path}"}
+            release.download(Pathname.new(path))
           end
 
         private

--- a/lib/librarian/puppet/util.rb
+++ b/lib/librarian/puppet/util.rb
@@ -71,6 +71,22 @@ module Librarian
         name.rpartition('-').last
       end
 
+      def download_file(url, path)
+        File.open(path, 'wb') do |f|
+          begin
+            debug { "Downloading <#{url}> to <#{f.path}>" }
+            open(url,
+                 "User-Agent" => "librarian-puppet v#{Librarian::Puppet::VERSION}") do |res|
+              while buffer = res.read(8192)
+                f.write(buffer)
+              end
+            end
+          rescue OpenURI::HTTPError => e
+            raise e, "Error requesting <#{url}>: #{e.to_s}"
+          end
+        end
+      end
+
       # deprecated
       alias :organization_name :module_name
     end

--- a/librarian-puppet.gemspec
+++ b/librarian-puppet.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
   automatically pulling in modules from the forge and git repositories with
   a single command.'
 
-  # puppet_forge gem requires ruby 1.9 so we do too, use version 1.x in ruby 1.8
-  s.required_ruby_version = '>= 1.9.0'
+  # json gem required by hiera requires ruby 2.0 so we do too, use version 1.x in ruby 1.8
+  s.required_ruby_version = '>= 2.0.0'
 
   s.files = [
     '.gitignore',


### PR DESCRIPTION
Currently the download uses the puppet command.  This breaks when used against hosted forge repos.  This change modifies the code to use the download feature in the puppet forge library.
