### PR TITLE
Fixup interaction with FORGE-383

### DIFF
--- a/lib/librarian/puppet/source/forge/repo_v3.rb
+++ b/lib/librarian/puppet/source/forge/repo_v3.rb
@@ -11,7 +11,7 @@ module Librarian
           PuppetForge.user_agent = "librarian-puppet/#{Librarian::Puppet::VERSION}"
 
           def initialize(source, name)
-            PuppetForge.host = source.uri.clone
+            PuppetForge.host = source.uri.clone.to_s
             super(source, name)
           end
 


### PR DESCRIPTION
The implementation of FORGE-383 in puppet_forge 2.2.5 breaks regular
operations by making the previously implied type of PuppetForge.host
(String) accidentally explicit by attempting substring operations on the
supplied uri.

Here we ensure we're calling .to_s to get the String that PuppetForge
expects.

    [Librarian]   Checking manifests
    /var/lib/gems/1.9.1/gems/puppet_forge-2.2.5/lib/puppet_forge.rb:10:in `host=': undefined method `[]' for #<URI::HTTPS:0x000000010b6fc0> (NoMethodError)
	from /var/lib/gems/1.9.1/gems/librarian-puppet-2.2.3/lib/librarian/puppet/source/forge/repo_v3.rb:14:in `initialize'
	from /var/lib/gems/1.9.1/gems/librarian-puppet-2.2.3/lib/librarian/puppet/source/forge.rb:163:in `new'
	from /var/lib/gems/1.9.1/gems/librarian-puppet-2.2.3/lib/librarian/puppet/source/forge.rb:163:in `repo'