### PR TITLE
Correct forge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 Librarian-puppet is a bundler for your puppet infrastructure.  You can use
 librarian-puppet to manage the puppet modules your infrastructure depends on,
-whether the modules come from the [Puppet Forge](https://forge.puppetlabs.com/),
+whether the modules come from the [Puppet Forge](https://forge.puppet.com/),
 Git repositories or just a path.
 
 * Librarian-puppet can reuse the dependencies listed in your `Modulefile` or `metadata.json`
-* Forge modules can be installed from [Puppetlabs Forge](https://forge.puppetlabs.com/) or an internal Forge such as [Pulp](http://www.pulpproject.org/)
+* Forge modules can be installed from [Puppetlabs Forge](https://forge.puppet.com/) or an internal Forge such as [Pulp](http://www.pulpproject.org/)
 * Git modules can be installed from a branch, tag or specific commit, optionally using a path inside the repository
 * Modules can be installed from GitHub using tarballs, without needing Git installed
 * Modules can be installed from a filesystem path

--- a/features/examples/duplicated_dependencies/Puppetfile
+++ b/features/examples/duplicated_dependencies/Puppetfile
@@ -1,3 +1,3 @@
-forge 'http://forge.puppetlabs.com'
+forge 'https://forgeapi.puppetlabs.com'
 
 metadata

--- a/features/examples/duplicated_dependencies_transitive/Puppetfile
+++ b/features/examples/duplicated_dependencies_transitive/Puppetfile
@@ -1,4 +1,4 @@
-forge 'http://forge.puppetlabs.com'
+forge 'https://forgeapi.puppetlabs.com'
 
 metadata
 

--- a/features/examples/metadata_syntax/Puppetfile
+++ b/features/examples/metadata_syntax/Puppetfile
@@ -1,3 +1,3 @@
-forge 'http://forge.puppetlabs.com'
+forge 'https://forgeapi.puppetlabs.com'
 
 metadata

--- a/features/examples/modulefile_syntax/Puppetfile
+++ b/features/examples/modulefile_syntax/Puppetfile
@@ -1,3 +1,3 @@
-forge 'http://forge.puppetlabs.com'
+forge 'https://forgeapi.puppetlabs.com'
 
 modulefile

--- a/features/examples/with_puppetfile_and_metadata_json/Puppetfile
+++ b/features/examples/with_puppetfile_and_metadata_json/Puppetfile
@@ -1,3 +1,3 @@
-forge 'http://forge.puppetlabs.com'
+forge 'https://forgeapi.puppetlabs.com'
 
 mod 'maestrodev/test'

--- a/features/examples/with_puppetfile_and_modulefile/Puppetfile
+++ b/features/examples/with_puppetfile_and_modulefile/Puppetfile
@@ -1,3 +1,3 @@
-forge 'http://forge.puppetlabs.com'
+forge 'https://forgeapi.puppetlabs.com'
 
 mod 'maestrodev/test'

--- a/features/install.feature
+++ b/features/install.feature
@@ -19,7 +19,7 @@ Feature: cli/install
   Scenario: Install a module transitive dependency from git and forge should be deterministic
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/stdlib', :git => 'https://github.com/puppetlabs/puppetlabs-stdlib.git', :ref => '4.6.0'
     mod 'librarian/test', :git => 'https://github.com/voxpupuli/librarian-puppet.git', :path => 'features/examples/test'
@@ -32,7 +32,7 @@ Feature: cli/install
   Scenario: Install duplicated dependencies from git and forge, last one wins
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     metadata
     mod 'puppetlabs-stdlib', :git => 'https://github.com/puppetlabs/puppetlabs-stdlib.git', :ref => '4.6.0'
@@ -82,7 +82,7 @@ Feature: cli/install
   Scenario: Install a module with Modulefile without version
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'librarian-bad_modulefile', :path => 'bad_modulefile'
     """
@@ -101,7 +101,7 @@ Feature: cli/install
   Scenario: Install a module with the rsync configuration using the --clean flag
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'maestrodev/test'
     """
@@ -125,7 +125,7 @@ Feature: cli/install
   Scenario: Install a module with the rsync configuration using the --destructive flag
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'maestrodev/test'
     """
@@ -150,7 +150,7 @@ Feature: cli/install
   Scenario: Install a module with the rsync configuration
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'maestrodev/test'
     """

--- a/features/install/forge.feature
+++ b/features/install/forge.feature
@@ -54,7 +54,7 @@ Feature: cli/install/forge
   Scenario: Installing an exact version of a module
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/apt', '0.0.4'
     """
@@ -71,7 +71,7 @@ Feature: cli/install/forge
   Scenario: Installing a module in a path with spaces
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
     mod 'puppetlabs/stdlib', '4.1.0'
     """
     When PENDING I run `librarian-puppet install`
@@ -81,7 +81,7 @@ Feature: cli/install/forge
   Scenario: Installing a module with invalid versions in the forge
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/apache', '0.4.0'
     mod 'puppetlabs/postgresql', '2.0.1'
@@ -97,7 +97,7 @@ Feature: cli/install/forge
   Scenario: Installing a module with several constraints
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/apt', '>=1.0.0', '<1.0.1'
     """
@@ -111,7 +111,7 @@ Feature: cli/install/forge
     Given a directory named "puppet"
     And a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/ntp', '3.0.3'
     """
@@ -125,7 +125,7 @@ Feature: cli/install/forge
   Scenario: Handle range version numbers
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/postgresql', '3.2.0'
     mod 'puppetlabs/apt', '< 1.4.1' # 1.4.2 causes trouble in travis
@@ -137,7 +137,7 @@ Feature: cli/install/forge
 
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/postgresql', :git => 'git://github.com/puppetlabs/puppet-postgresql', :ref => '3.3.0'
     """
@@ -149,7 +149,7 @@ Feature: cli/install/forge
   Scenario: Installing a module that does not exist
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/xxxxx'
     """
@@ -157,13 +157,13 @@ Feature: cli/install/forge
     Then the exit status should be 1
     And the output should match:
       """
-      Unable to find module 'puppetlabs-xxxxx' on http(s)?://forge(api)?.puppetlabs.com
+      Unable to find module 'puppetlabs-xxxxx' on https://forgeapi.puppetlabs.com
       """
 
   Scenario: Install a module with conflicts
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/apache', '0.6.0'
     mod 'puppetlabs/stdlib', '<2.2.1'
@@ -175,7 +175,7 @@ Feature: cli/install/forge
   Scenario: Install a module from the Forge with dependencies without version
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'sbadia/gitlab', '0.1.0'
     """
@@ -186,7 +186,7 @@ Feature: cli/install/forge
   Scenario: Source dependencies from Modulefile
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     modulefile
     """
@@ -202,7 +202,7 @@ Feature: cli/install/forge
   Scenario: Source dependencies from metadata.json
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     metadata
     """
@@ -225,7 +225,7 @@ Feature: cli/install/forge
   Scenario: Source dependencies from Modulefile using dash instead of slash
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     modulefile
     """
@@ -241,7 +241,7 @@ Feature: cli/install/forge
   Scenario: Installing a module with duplicated dependencies
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'pdxcat/collectd', '2.1.0'
     """
@@ -253,7 +253,7 @@ Feature: cli/install/forge
   Scenario: Installing two modules with same name, alphabetical order wins
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'theforeman-dhcp', '4.0.0'
     mod 'puppet-dhcp', '2.0.0'

--- a/features/install/forge.feature
+++ b/features/install/forge.feature
@@ -193,11 +193,11 @@ Feature: cli/install/forge
     And a file named "Modulefile" with:
     """
     name "random name"
-    dependency "puppetlabs/postgresql", "2.4.1"
+    dependency "puppetlabs/postgresql", "4.0.0"
     """
     When I run `librarian-puppet install`
     Then the exit status should be 0
-    And the file "modules/postgresql/Modulefile" should match /name *'puppetlabs-postgresql'/
+    And the file "modules/postgresql/metadata.json" should match /"name": "puppetlabs-postgresql"/
 
   Scenario: Source dependencies from metadata.json
     Given a file named "Puppetfile" with:
@@ -213,14 +213,14 @@ Feature: cli/install/forge
       "dependencies": [
         {
           "name": "puppetlabs/postgresql",
-          "version_requirement": "2.4.1"
+          "version_requirement": "4.0.0"
         }
       ]
     }
     """
     When I run `librarian-puppet install`
     Then the exit status should be 0
-    And the file "modules/postgresql/Modulefile" should match /name *'puppetlabs-postgresql'/
+    And the file "modules/postgresql/metadata.json" should match /"name": "puppetlabs-postgresql"/
 
   Scenario: Source dependencies from Modulefile using dash instead of slash
     Given a file named "Puppetfile" with:
@@ -232,11 +232,11 @@ Feature: cli/install/forge
     And a file named "Modulefile" with:
     """
     name "random name"
-    dependency "puppetlabs-postgresql", "2.4.1"
+    dependency "puppetlabs-postgresql", "4.0.0"
     """
     When I run `librarian-puppet install`
     Then the exit status should be 0
-    And the file "modules/postgresql/Modulefile" should match /name *'puppetlabs-postgresql'/
+    And the file "modules/postgresql/metadata.json" should match /"name": "puppetlabs-postgresql"/
 
   Scenario: Installing a module with duplicated dependencies
     Given a file named "Puppetfile" with:
@@ -255,13 +255,13 @@ Feature: cli/install/forge
     """
     forge "http://forge.puppetlabs.com"
 
-    mod 'ripienaar-concat', '0.2.0'
-    mod 'puppetlabs-concat', '1.2.0'
+    mod 'theforeman-dhcp', '4.0.0'
+    mod 'puppet-dhcp', '2.0.0'
     """
     When I run `librarian-puppet install --verbose`
     Then the exit status should be 0
-    And the file "modules/concat/metadata.json" should match /"name": "ripienaar-concat"/
-    And the output should contain "Dependency on module 'concat' is fullfilled by multiple modules and only one will be used"
+    And the file "modules/dhcp/metadata.json" should match /"name": "theforeman-dhcp"/
+    And the output should contain "Dependency on module 'dhcp' is fullfilled by multiple modules and only one will be used"
 
   @other-forge
   Scenario: Installing from another forge with local reference should not try to download anything from the official forge

--- a/features/install/git.feature
+++ b/features/install/git.feature
@@ -4,7 +4,7 @@ Feature: cli/install/git
   Scenario: Installing a module from git
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/apache',
         :git => 'https://github.com/puppetlabs/puppetlabs-apache.git', :ref => '1.4.0'
@@ -34,7 +34,7 @@ Feature: cli/install/git
   Scenario: Installing a module with invalid versions in git
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod "apache",
       :git => "https://github.com/puppetlabs/puppetlabs-apache.git", :ref => "1.4.0"
@@ -47,7 +47,7 @@ Feature: cli/install/git
   Scenario: Switching a module from forge to git
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/postgresql', '4.0.0'
     """
@@ -58,7 +58,7 @@ Feature: cli/install/git
     And the file "modules/stdlib/metadata.json" should match /"name": "puppetlabs-stdlib"/
     When I overwrite "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/postgresql',
       :git => 'https://github.com/puppetlabs/puppetlabs-postgresql.git', :ref => '4.3.0'
@@ -113,7 +113,7 @@ Feature: cli/install/git
   Scenario: Running install with no Modulefile nor metadata.json
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/stdlib', :git => 'https://github.com/puppetlabs/puppetlabs-stdlib.git', :ref => '4.6.0'
     """
@@ -123,7 +123,7 @@ Feature: cli/install/git
   Scenario: Running install with metadata.json without dependencies
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/sqlite', :git => 'https://github.com/puppetlabs/puppetlabs-sqlite.git', :ref => '84a0a6'
     """
@@ -153,7 +153,7 @@ Feature: cli/install/git
   Scenario: Install a module from git and using path
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'librarian-test', :git => 'https://github.com/voxpupuli/librarian-puppet.git', :path => 'features/examples/test'
     """
@@ -165,7 +165,7 @@ Feature: cli/install/git
   Scenario: Install a module from git without version
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'test', :git => 'https://github.com/voxpupuli/librarian-puppet.git', :path => 'features/examples/dependency_without_version'
     """

--- a/features/install/github_tarball.feature
+++ b/features/install/github_tarball.feature
@@ -5,7 +5,7 @@ Feature: cli/install/github_tarball
   Scenario: Installing a module from github tarballs
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/apache', '0.6.0', :github_tarball => 'puppetlabs/puppetlabs-apache'
     mod 'puppetlabs/stdlib', '2.3.0', :github_tarball => 'puppetlabs/puppetlabs-stdlib'

--- a/features/install/path.feature
+++ b/features/install/path.feature
@@ -45,7 +45,7 @@ Feature: cli/install/path
   Scenario: Install a module from path without version
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'test', :path => '../../features/examples/dependency_without_version'
     """

--- a/features/outdated.feature
+++ b/features/outdated.feature
@@ -4,14 +4,14 @@ Feature: cli/outdated
   Scenario: Running outdated with forge modules
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/stdlib', '>=3.1.x'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forgeapi.puppetlabs.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -28,14 +28,14 @@ Feature: cli/outdated
   Scenario: Running outdated with git modules
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'test', :git => 'https://github.com/voxpupuli/librarian-puppet.git', :path => 'features/examples/test'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forgeapi.puppetlabs.com
       specs:
         puppetlabs/stdlib (3.1.0)
 

--- a/features/package.feature
+++ b/features/package.feature
@@ -4,7 +4,7 @@ Feature: cli/package
   Scenario: Packaging a forge module
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/apt', '1.4.0'
     mod 'puppetlabs/stdlib', '4.1.0'
@@ -20,7 +20,7 @@ Feature: cli/package
   Scenario: Packaging a git module
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/apt', '1.5.0', :git => 'https://github.com/puppetlabs/puppetlabs-apt.git', :ref => '1.5.0'
     mod 'puppetlabs/stdlib', '4.1.0'
@@ -37,7 +37,7 @@ Feature: cli/package
   Scenario: Packaging a github tarball module
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/apt', '1.4.0', :github_tarball => 'puppetlabs/puppetlabs-apt'
     mod 'puppetlabs/stdlib', '4.1.0'

--- a/features/update.feature
+++ b/features/update.feature
@@ -17,7 +17,7 @@ Feature: cli/update
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forgeapi.puppetlabs.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -40,7 +40,7 @@ Feature: cli/update
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forgeapi.puppetlabs.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -57,14 +57,14 @@ Feature: cli/update
   Scenario: Updating a module
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/stdlib', '3.1.x'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forgeapi.puppetlabs.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -80,14 +80,14 @@ Feature: cli/update
   Scenario: Updating a module using organization/module
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/stdlib', '3.1.x'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forgeapi.puppetlabs.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -103,7 +103,7 @@ Feature: cli/update
   Scenario: Updating a module from git with a branch ref
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod "puppetlabs-stdlib",
       :git => "https://github.com/puppetlabs/puppetlabs-stdlib.git", :ref => "3.2.x"
@@ -130,7 +130,7 @@ Feature: cli/update
   Scenario: Updating a module with invalid versions in git
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod "apache",
       :git => "https://github.com/puppetlabs/puppetlabs-apache.git", :ref => "0.5.0-rc1"
@@ -138,7 +138,7 @@ Feature: cli/update
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forgeapi.puppetlabs.com
       specs:
         puppetlabs/firewall (0.0.4)
         puppetlabs/stdlib (3.2.0)
@@ -164,14 +164,14 @@ Feature: cli/update
   Scenario: Updating a module that is not in the Puppetfile
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'puppetlabs/stdlib', '3.1.x'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forgeapi.puppetlabs.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -185,14 +185,14 @@ Feature: cli/update
   Scenario: Updating a module to a .10 release to ensure versions are correctly ordered
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'maestrodev/test'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forgeapi.puppetlabs.com
       specs:
         maestrodev/test (1.0.2)
 
@@ -208,14 +208,14 @@ Feature: cli/update
   Scenario: Updating a forge module with the rsync configuration
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod 'maestrodev/test'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: http://forge.puppetlabs.com
+      remote: https://forgeapi.puppetlabs.com
       specs:
         maestrodev/test (1.0.2)
 
@@ -243,7 +243,7 @@ Feature: cli/update
   Scenario: Updating a git module with the rsync configuration
     Given a file named "Puppetfile" with:
     """
-    forge "http://forge.puppetlabs.com"
+    forge "https://forgeapi.puppetlabs.com"
 
     mod "puppetlabs-stdlib",
       :git => "https://github.com/puppetlabs/puppetlabs-stdlib.git", :ref => "3.2.x"

--- a/lib/librarian/puppet/source/forge/repo.rb
+++ b/lib/librarian/puppet/source/forge/repo.rb
@@ -87,7 +87,7 @@ module Librarian
             target = vendored?(name, version) ? vendored_path(name, version).to_s : name
 
             # can't pass the default v3 forge url (http://forgeapi.puppetlabs.com)
-            # to clients that use the v1 API (https://forge.puppetlabs.com)
+            # to clients that use the v1 API (https://forge.puppet.com)
             # nor the other way around
             module_repository = source.to_s
 

--- a/lib/librarian/puppet/source/forge/repo_v1.rb
+++ b/lib/librarian/puppet/source/forge/repo_v1.rb
@@ -11,10 +11,10 @@ module Librarian
           def initialize(source, name)
             super(source, name)
             # API returned data for this module including all versions and dependencies, indexed by module name
-            # from http://forge.puppetlabs.com/api/v1/releases.json?module=#{name}
+            # from https://forge.puppetlabs.com/api/v1/releases.json?module=#{name}
             @api_data = nil
             # API returned data for this module and a specific version, indexed by version
-            # from http://forge.puppetlabs.com/api/v1/releases.json?module=#{name}&version=#{version}
+            # from https://forge.puppetlabs.com/api/v1/releases.json?module=#{name}&version=#{version}
             @api_version_data = {}
           end
 

--- a/spec/source/forge_repo_spec.rb
+++ b/spec/source/forge_repo_spec.rb
@@ -4,7 +4,7 @@ require "librarian/puppet/environment"
 describe Librarian::Puppet::Source::Forge::Repo do
 
   let(:environment) { Librarian::Puppet::Environment.new }
-  let(:uri) { "https://forge.puppetlabs.com" }
+  let(:uri) { "https://forgeapi.puppetlabs.com" }
   let(:source) { Librarian::Puppet::Source::Forge.new(environment, uri) }
   subject { Librarian::Puppet::Source::Forge::Repo.new(source, "puppetlabs/stdlib") }
 

--- a/spec/source/forge_spec.rb
+++ b/spec/source/forge_spec.rb
@@ -7,7 +7,7 @@ include Librarian::Puppet::Source
 describe Forge do
 
   let(:environment) { Librarian::Puppet::Environment.new }
-  let(:uri) { "https://forge.puppetlabs.com" }
+  let(:uri) { "https://forgeapi.puppetlabs.com" }
   let(:puppet_version) { "3.6.0" }
   subject { Forge.new(environment, uri) }
 


### PR DESCRIPTION
This fixes an existing issue in the tests because ripienaar-concat was pulled from the forge.

Then it moves to the current forge URLs.

Closes GH-23
Closes GH-24
Closes GH-25