### PR TITLE
Fix comment on choice of V1/V3 api

### DIFF
--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -158,7 +158,8 @@ module Librarian
           @repo ||= {}
 
           unless @repo[name]
-            # if we are using the official Forge then use API v3, otherwise stick to v1 for now
+            # If we are using the official Forge then use API v3, otherwise use the preferred api 
+            # as defined by the CLI option use_v1_api
             if uri.hostname =~ /\.puppetlabs\.com$/ || !environment.use_v1_api
               @repo[name] = RepoV3.new(self, name)
             else


### PR DESCRIPTION
Updated the comment to reflect that unless we're talking to puppetlabs.com (in which case we ignore the API that the user has picked) we use the value of the CLI option use_v1_api.

Note: I ran into this whilst trying to get librarian-puppet working against artifactory. The specific issue there was resolved by upgrading the puppet-agent to a 1.10 release from 1.9 (related to the fix in puppet-forge 2.2.2 -> 2.2.3 about dropping the context path from a URL). Anyway, the point is that the behaviour to fallback from V3 -> V1 without notifying the user took me down a bit of a rabbit hole resulting in this comment fix. Just an FYI in case you want to make something of it - it only took 30 minutes of reviewing code before it was pretty obvious what the issue was so not a big deal.