### PR TITLE
Prepare release 3.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,22 @@
 # Changelog
 
-## From 2.x Librarian-Puppet requires Ruby >= 1.9, uses Puppet Forge API v3. For Ruby 1.8 use 1.x
+### Breaking Changes
+
+Librarian-Puppet 3.0.0 and newer requires Ruby >= 2.0. Use version 2.2.4 if you need support for Puppet 3.7 or earlier, or Ruby 1.9 or earlier. Note that Puppet 4.10 and [newer require Ruby 2.1](https://puppet.com/docs/puppet/4.10/system_requirements.html#prerequisites) or newer.
+
+Librarian-Puppet 2.0.0 and newer requires Ruby >= 1.9 and uses Puppet Forge API v3. For Ruby 1.8 use 1.5.0.
+
+### 3.0.0
+
+ * [PR #1](https://github.com/voxpupuli/librarian/pull/1) Add support for r10k Puppetfile's opts
+ * [PR #5](https://github.com/voxpupuli/librarian-puppet/pull/9) Update README for r10k syntax from PR #1.
+ * [PR #8](https://github.com/voxpupuli/librarian-puppet/pull/8) Clean up tests
+ * [PR #19](https://github.com/voxpupuli/librarian-puppet/pull/19) Fix rsync on Windows (path conversion, return code checking) and add trailing /
+ * [Issue #20](https://github.com/voxpupuli/librarian-puppet/issues/20) Ignore Gem files
+ * [Issue #25](https://github.com/voxpupuli/librarian-puppet/pull/25) Move to https and new forge url
+ * Avoid deleted ripienaar-concat
+ * [PR #59](https://github.com/voxpupuli/librarian-puppet/pull/59) Fix tests
+ * [PR #61](https://github.com/voxpupuli/librarian-puppet/pull/61) Bring testing matrix up to date
 
 ### 2.2.3
 
@@ -26,7 +42,7 @@
 
  * Update librarian to use the new `exclusion` syntax
  * [Issue #282](https://github.com/rodjek/librarian-puppet/issues/282) Merge duplicated dependencies and warn the user, no more `Cannot bounce Puppetfile.lock!` errors
- * [Issue #217](https://github.com/rodjek/librarian-puppet/issues/217)[Issue #244](https://github.com/rodjek/librarian-puppet/issues/244) Use librarianp 0.4.0 that no longer uses recursion to avoid `stack level too deep` errors
+ * [Issue #217](https://github.com/rodjek/librarian-puppet/issues/217), [Issue #244](https://github.com/rodjek/librarian-puppet/issues/244) Use librarianp 0.4.0 that no longer uses recursion to avoid `stack level too deep` errors
  * [Issue #277](https://github.com/rodjek/librarian-puppet/issues/277) Warn when there are two dependencies with the same module name
  * Use `librarianp` gem instead of `librarian`, a fork with the needed improvements and fixes.
 
@@ -48,7 +64,7 @@
 
  * Update librarian to use the new `exclusion` syntax
  * [Issue #282](https://github.com/rodjek/librarian-puppet/issues/282) Merge duplicated dependencies and warn the user, no more `Cannot bounce Puppetfile.lock!` errors
- * [Issue #217](https://github.com/rodjek/librarian-puppet/issues/217)[Issue #244](https://github.com/rodjek/librarian-puppet/issues/244) Use librarianp 0.4.0 that no longer uses recursion to avoid `stack level too deep` errors
+ * [Issue #217](https://github.com/rodjek/librarian-puppet/issues/217), [Issue #244](https://github.com/rodjek/librarian-puppet/issues/244) Use librarianp 0.4.0 that no longer uses recursion to avoid `stack level too deep` errors
  * [Issue #277](https://github.com/rodjek/librarian-puppet/issues/277) Warn when there are two dependencies with the same module name
  * Use `librarianp` gem instead of `librarian`, a fork with the needed improvements and fixes.
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ and isolate a project's dependencies.
 
 ## Versions
 
-Librarian-puppet >= 2.0 (as well as 1.1, 1.2 and 1.3) requires Ruby 1.9 and uses the Puppet Forge API v3.
-Versions < 2.0 work on Ruby 1.8.
+Librarian-Puppet 3.0.0 and newer requires Ruby >= 2.0. Use version 2.2.4 if you need support for Puppet 3.7 or earlier, or Ruby 1.9 or earlier. Note that [Puppet 4.10 and newer require Ruby 2.1](https://puppet.com/docs/puppet/4.10/system_requirements.html#prerequisites) or newer.
+
+Librarian-Puppet 2.0.0 and newer requires Ruby >= 1.9 and uses Puppet Forge API v3. For Ruby 1.8 use 1.5.0.
 
 See the [Changelog](Changelog.md) for more details.
 

--- a/lib/librarian/puppet/version.rb
+++ b/lib/librarian/puppet/version.rb
@@ -1,5 +1,5 @@
 module Librarian
   module Puppet
-    VERSION = "2.2.3"
+    VERSION = "3.0.0"
   end
 end

--- a/librarian-puppet.gemspec
+++ b/librarian-puppet.gemspec
@@ -15,8 +15,7 @@ Gem::Specification.new do |s|
   automatically pulling in modules from the forge and git repositories with
   a single command.'
 
-  # puppet_forge gem requires ruby 1.9 so we do too, use version 1.x in ruby 1.8
-  s.required_ruby_version = '>= 1.9.0'
+  s.required_ruby_version = '>= 2.0.0'
 
   s.files = [
     '.gitignore',


### PR DESCRIPTION
See Changelog.md for details.

As part of the release, adjust testing matrix to recent versions of Ruby and Puppet. Puppet 3.8 does not support Ruby 2.2 or newer, so these combinations are excluded from the testing matrix.