### PR TITLE
Fix tests

### DIFF
--- a/features/install/forge.feature
+++ b/features/install/forge.feature
@@ -85,9 +85,11 @@ Feature: cli/install/forge
 
     mod 'puppetlabs/apache', '0.4.0'
     mod 'puppetlabs/postgresql', '2.0.1'
+    mod 'puppetlabs-firewall', '<= 1.9.0' # apache has an unqualified dependency on firewall, which in turn pulls in a too-new version of stdlib
     mod 'puppetlabs/apt', '< 1.4.1' # 1.4.2 causes trouble in travis
+
     """
-    When I run `librarian-puppet install`
+    When I run `librarian-puppet install --verbose`
     Then the exit status should be 0
     And the file "modules/apache/Modulefile" should match /name *'puppetlabs-apache'/
     And the file "modules/apache/Modulefile" should match /version *'0\.4\.0'/

--- a/librarian-puppet.gemspec
+++ b/librarian-puppet.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
-  s.add_development_dependency "cucumber"
+  s.add_development_dependency "cucumber", "<3.0.0"
   s.add_development_dependency "aruba", "<0.8.0"
   s.add_development_dependency "puppet", ENV["PUPPET_VERSION"]
   s.add_development_dependency "minitest", "~> 5"


### PR DESCRIPTION
* for Ruby 2.2 and Puppet 4.2.0
* Use Ruby 2.0-compatible version of cucumber

Hopefully this is enough to proceed with issue #55 and PR #58.