### PR TITLE
[#17] Added the configuration parameter 'use-short-cache-path'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,12 @@ Configuration affects how various commands operate.
   path, it is relative to the directory containing the `Puppetfile`. The
   equivalent environment variable is `LIBRARIAN_PUPPET_TMP`.
 
+* The `use-short-cache-path` config shortens the cache path part of the Puppet
+  forge URI to the 7 first digits of its SHA1 checksum. This helps additionally
+  to the `tmp` config to avoid too long paths under Windows. Under Windows this
+  is especially important when you use an alternative Puppet forge with a quite
+  longer URI.
+
 Configuration can be set by passing specific options to other commands.
 
 * The `path` config can be set at the local level by passing the `--path` option

--- a/lib/librarian/puppet/cli.rb
+++ b/lib/librarian/puppet/cli.rb
@@ -47,6 +47,7 @@ module Librarian
       option "destructive", :type => :boolean, :default => false
       option "local", :type => :boolean, :default => false
       option "use-v1-api", :type => :boolean, :default => true
+      option "use-short-cache-path", :type => :boolean, :default => false
       def install
 
         ensure!
@@ -64,6 +65,7 @@ module Librarian
 
         environment.config_db.local['use-v1-api'] = options['use-v1-api'] ? '1' : nil
         environment.config_db.local['mode'] = options['local'] ? 'local' : nil
+        environment.config_db.local['use-short-cache-path'] = options['use-short-cache-path'] ? '1' : nil
 
         resolve!
         debug { "Install: dependencies resolved"}

--- a/lib/librarian/puppet/environment.rb
+++ b/lib/librarian/puppet/environment.rb
@@ -57,6 +57,10 @@ module Librarian
       def use_v1_api
         config_db['use-v1-api']
       end
+
+      def use_short_cache_path
+        config_db['use-short-cache-path']
+      end
     end
   end
 end

--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -123,7 +123,14 @@ module Librarian
 
         def cache_path
           @cache_path ||= begin
-            dir = "#{uri.host}#{uri.path}".gsub(/[^0-9a-z\-_]/i, '_')
+            if environment.use_short_cache_path
+              # To shorten the cache path to avoid #17
+              # take only the first 7 digits of the SHA1 checksum of the forge URI
+              # (short Git commit hash approach)
+              dir = Digest::SHA1.hexdigest("#{uri.host}#{uri.path}")[0..6]
+            else
+              dir = "#{uri.host}#{uri.path}".gsub(/[^0-9a-z\-_]/i, '_')
+            end
             environment.cache_path.join("source/puppet/forge/#{dir}")
           end
         end


### PR DESCRIPTION
Additionally to the configuration parameter 'tmp', this parameter is helpful to avoid too long cache paths under Windows.

This is achieved by shortening the cache path part of the Puppet forge URI to the 7 first digits of its SHA1 checksum (like short Git commit hash approach).

Under Windows this shortening is especially important when you use an alternative Puppet forge with a quite longer URI.