### PR TITLE
Allow dependency cycles

### DIFF
--- a/lib/librarian/puppet/action/install.rb
+++ b/lib/librarian/puppet/action/install.rb
@@ -20,6 +20,10 @@ module Librarian
           # don't fail if Puppetfile doesn't exist as we'll use the Modulefile or metadata.json
         end
 
+        def sorted_manifests
+          lock.manifests
+        end
+
       end
     end
   end

--- a/lib/librarian/puppet/action/resolve.rb
+++ b/lib/librarian/puppet/action/resolve.rb
@@ -1,4 +1,5 @@
 require 'librarian/action/resolve'
+require 'librarian/puppet/resolver'
 
 module Librarian
   module Puppet
@@ -13,6 +14,10 @@ module Librarian
           dupes.each do |k,v|
             warn("Dependency on module '#{k}' is fullfilled by multiple modules and only one will be used: #{v.map{|m|m.name}}")
           end
+        end
+
+        def resolver
+          Resolver.new(environment, cyclic: true)
         end
 
       end

--- a/lib/librarian/puppet/lockfile.rb
+++ b/lib/librarian/puppet/lockfile.rb
@@ -28,6 +28,20 @@ module Librarian
           super(lines, manifests_index)
         end
 
+        def compile(sources_ast)
+          manifests = compile_placeholder_manifests(sources_ast)
+          manifests = manifests.map do |name, manifest|
+            dependencies = manifest.dependencies.map do |d|
+              environment.dsl_class.dependency_type.new(d.name, d.requirement, manifests[d.name].source)
+            end
+            real = Manifest.new(manifest.source, manifest.name)
+            real.version = manifest.version
+            real.dependencies = manifest.dependencies
+            real
+          end
+          manifests.sort_by(&:name)
+        end
+
       end
 
       def load(string)

--- a/lib/librarian/puppet/resolver.rb
+++ b/lib/librarian/puppet/resolver.rb
@@ -1,0 +1,14 @@
+require 'librarian/resolver'
+
+module Librarian
+  module Puppet
+    class Resolver < Librarian::Resolver
+
+      def sort(manifests)
+        manifests = manifests.values if Hash === manifests
+        manifests.sort_by(&:name)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
These changes allow for modules to have cross-dependencies. As far as I can tell, there should be no issue with cycles since install order is not important, only that all modules get installed. If setting the `Resolver` to `cyclic: true` globally is undesirable, perhaps a config flag could be added to support cyclic modules.