### PR TITLE
Specify dependent module in dependencies

### DIFF
--- a/lib/librarian/puppet/action/resolve.rb
+++ b/lib/librarian/puppet/action/resolve.rb
@@ -1,4 +1,5 @@
 require 'librarian/action/resolve'
+require 'librarian/puppet/resolver'
 
 module Librarian
   module Puppet
@@ -13,6 +14,10 @@ module Librarian
           dupes.each do |k,v|
             warn("Dependency on module '#{k}' is fullfilled by multiple modules and only one will be used: #{v.map{|m|m.name}}")
           end
+        end
+
+        def resolver
+          Resolver.new(environment)
         end
 
       end

--- a/lib/librarian/puppet/dependency.rb
+++ b/lib/librarian/puppet/dependency.rb
@@ -5,11 +5,19 @@ module Librarian
 
       include Librarian::Puppet::Util
 
-      def initialize(name, requirement, source)
+      attr_accessor :parent
+      private :parent=
+
+      def initialize(name, requirement, source, parent = nil)
         # Issue #235 fail if forge source is not defined
         raise Error, "forge entry is not defined in Puppetfile" if source.instance_of?(Array) && source.empty?
 
+        self.parent = parent
         super(normalize_name(name), requirement, source)
+      end
+
+      def to_s
+        "#{name} (#{requirement}) <#{source}> (from #{parent.nil? ? '<nil>' : parent})"
       end
 
     end

--- a/lib/librarian/puppet/resolver.rb
+++ b/lib/librarian/puppet/resolver.rb
@@ -1,0 +1,21 @@
+require 'librarian/resolver'
+
+module Librarian
+  module Puppet
+    class Resolver < Librarian::Resolver
+
+      class Implementation < Librarian::Resolver::Implementation
+        def sourced_dependency_for(dependency)
+          return dependency if dependency.source
+
+          source = dependency_source_map[dependency.name] || default_source
+          dependency.class.new(dependency.name, dependency.requirement, source, dependency.parent)
+        end
+      end
+
+      def implementation(spec)
+        Implementation.new(self, spec, :cyclic => cyclic)
+      end
+    end
+  end
+end

--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -144,7 +144,7 @@ module Librarian
         def fetch_dependencies(name, version, version_uri)
           repo(name).dependencies(version).map do |k, v|
             v = Librarian::Dependency::Requirement.new(v).to_gem_requirement
-            Dependency.new(k, v, nil)
+            Dependency.new(k, v, nil, name)
           end
         end
 

--- a/lib/librarian/puppet/source/local.rb
+++ b/lib/librarian/puppet/source/local.rb
@@ -44,7 +44,7 @@ module Librarian
 
           parsed_metadata['dependencies'].each do |d|
             gem_requirement = Librarian::Dependency::Requirement.new(d['version_requirement']).to_gem_requirement
-            new_dependency = Dependency.new(d['name'], gem_requirement, forge_source)
+            new_dependency = Dependency.new(d['name'], gem_requirement, forge_source, name)
             dependencies << new_dependency
           end
 


### PR DESCRIPTION
This commit adds the origin of the dependency to verbose output, making it easier to determine which
source/module is causing a conflict.

For example:
```
Failed to resolve puppetlabs-concat (= 5.1.1) <https://forgeapi.puppetlabs.com>
```
becomes
```
Failed to resolve puppetlabs-concat (= 5.1.1) <https://forgeapi.puppetlabs.com> (from Puppetfile)
```