### PR TITLE
Support basic auth for forge

### DIFF
--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -91,7 +91,7 @@ module Librarian
         end
 
         def to_lock_options
-          {:remote => clean_uri(uri).to_s}
+          {:remote => uri.to_s}
         end
 
         def pinned?

--- a/lib/librarian/puppet/source/forge/repo.rb
+++ b/lib/librarian/puppet/source/forge/repo.rb
@@ -89,7 +89,7 @@ module Librarian
             # can't pass the default v3 forge url (http://forgeapi.puppetlabs.com)
             # to clients that use the v1 API (https://forge.puppet.com)
             # nor the other way around
-            module_repository = source.to_s
+            module_repository = source.uri.to_s
 
             if Forge.client_api_version() > 1 and module_repository =~ %r{^http(s)?://forge\.puppetlabs\.com}
               module_repository = "https://forgeapi.puppetlabs.com"
@@ -109,7 +109,7 @@ module Librarian
 
             command = %W{puppet module install --version #{version} --target-dir}
             command.push(*[path.to_s, "--module_repository", module_repository, "--modulepath", path.to_s, "--module_working_dir", path.to_s, "--ignore-dependencies", target])
-            debug { "Executing puppet module install for #{name} #{version}: #{command.join(" ")}" }
+            debug { "Executing puppet module install for #{name} #{version}: #{command.join(" ").gsub(module_repository, source.to_s)}" }
 
             begin
               Librarian::Posix.run!(command)


### PR DESCRIPTION
Add support for http basic auth for custom forge repo's while still ensuring that the uri's userinfo is not printed to console.

Result of changes
- `puppet module install` will be passed the basic auth information when run
- Now adds basic auth information to Puppetfile.lock to prevent the error `Puppetfile and Puppetfile.lock are out of sync!`