### PR TITLE
Add --[no-]use-v1-api option to update command

### DIFF
--- a/lib/librarian/puppet/cli.rb
+++ b/lib/librarian/puppet/cli.rb
@@ -70,9 +70,16 @@ module Librarian
         install!
       end
 
-      # only used to replace / to - in the module names
+      desc "update", "Updates and installs the dependencies you specify."
+      option "verbose", :type => :boolean, :default => false
+      option "line-numbers", :type => :boolean, :default => false
+      option "use-v1-api", :type => :boolean, :default => true
       def update(*names)
+
+        environment.config_db.local['use-v1-api'] = options['use-v1-api'] ? '1' : nil
+
         warn("Usage of module/name is deprecated, use module-name") if names.any? {|n| n.include?("/")}
+        # replace / to - in the module names
         super(*names.map{|n| normalize_name(n)})
       end
 


### PR DESCRIPTION
Currently, the default API used by librarian is v1, with an option in
the install command to use the v3 API instead. This option is missing,
however, from the update command, which means that unofficial Forges
that implement the v3 API cannot be reliably updated from. This adds the
option to use either API version when updating.