### PR TITLE
Fix calling issue with open-uri

### DIFF
--- a/lib/librarian/puppet/source/forge/repo.rb
+++ b/lib/librarian/puppet/source/forge/repo.rb
@@ -145,7 +145,7 @@ module Librarian
             debug { "Downloading #{url} into #{path}"}
             environment.vendor!
             File.open(path, 'wb') do |f|
-              open(url, "rb") do |input|
+              URI.open(url, 'rb') do |input|
                 f.write(input.read)
               end
             end

--- a/lib/librarian/puppet/source/forge/repo_v1.rb
+++ b/lib/librarian/puppet/source/forge/repo_v1.rb
@@ -74,7 +74,7 @@ module Librarian
             debug { "Querying Forge API for module #{name}#{" and version #{version}" unless version.nil?}: #{url}" }
 
             begin
-              data = open(url) {|f| f.read}
+              data = URI.open(url) {|f| f.read}
               JSON.parse(data)
             rescue OpenURI::HTTPError => e
               case e.io.status[0].to_i

--- a/lib/librarian/puppet/source/githubtarball/repo.rb
+++ b/lib/librarian/puppet/source/githubtarball/repo.rb
@@ -77,7 +77,7 @@ module Librarian
             File.open(vendored_path(vendored_name(name), version).to_s, 'wb') do |f|
               begin
                 debug { "Downloading <#{url}> to <#{f.path}>" }
-                open(url,
+                URI.open(url,
                   "User-Agent" => "librarian-puppet v#{Librarian::Puppet::VERSION}") do |res|
                   while buffer = res.read(8192)
                     f.write(buffer)


### PR DESCRIPTION
Following the deprecation of using `Kernel#open` directly, `open-uri` started issuing a warning to not use `open` without being called with the appropriate wrappers.

This apparently interfers with the monkey-patched `Librarian::Puppet::Logger#warn` method by passing two arguments:

```
warn('calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open', uplevel: 1)
[...]
1: from /home/twolter/.gem/ruby/2.7.0/gems/librarian-puppet-3.0.0/lib/librarian/puppet/util.rb:15:in `warn'
/opt/puppetlabs/bolt/lib/ruby/gems/2.7.0/gems/librarianp-1.0.0/lib/librarian/logger.rb:15:in `warn': wrong number of arguments (given 2, expected 0..1) (ArgumentError)
```

With this PR, `open` has been replaced by `URI.open`, which works perfectly.