### PR TITLE
Drop Puppet 3/Puppet 4 and Ruby 2.0/2.1/2.2 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,27 +13,10 @@ env:
   - PUPPET_VERSION="~> 5.2.0"
   - PUPPET_VERSION="~> 5.1.0"
   - PUPPET_VERSION="~> 5.0.0"
-  - PUPPET_VERSION="~> 4.10.0"
-  - PUPPET_VERSION="~> 4.9.0"
-  - PUPPET_VERSION="~> 4.8.0"
-  - PUPPET_VERSION="~> 3.8.0"
 
 matrix:
   exclude:
-    # monkeypatches failing for Puppet 3.8 on Ruby 2.1 through 2.4
-    - rvm: '2.4'
-      env: PUPPET_VERSION="~> 3.8.0"
-    - rvm: '2.3'
-      env: PUPPET_VERSION="~> 3.8.0"
-    - rvm: '2.2'
-      env: PUPPET_VERSION="~> 3.8.0"
     # Newer Puppet versions do not support old Ruby versions
-    - rvm: '2.0'
-      env: PUPPET_VERSION="~> 4.8.0"
-    - rvm: '2.0'
-      env: PUPPET_VERSION="~> 4.9.0"
-    - rvm: '2.0'
-      env: PUPPET_VERSION="~> 4.10.0"
     - rvm: '2.0'
       env: PUPPET_VERSION="~> 5.0.0"
     - rvm: '2.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ sudo: false
 rvm:
   - '2.4'
   - '2.3'
-  - '2.2'
-  - '2.1'
-  - '2.0'
+
 notifications:
   email:
     - tim@github.com
@@ -13,18 +11,6 @@ env:
   - PUPPET_VERSION="~> 5.2.0"
   - PUPPET_VERSION="~> 5.1.0"
   - PUPPET_VERSION="~> 5.0.0"
-
-matrix:
-  exclude:
-    # Newer Puppet versions do not support old Ruby versions
-    - rvm: '2.0'
-      env: PUPPET_VERSION="~> 5.0.0"
-    - rvm: '2.0'
-      env: PUPPET_VERSION="~> 5.1.0"
-    - rvm: '2.0'
-      env: PUPPET_VERSION="~> 5.2.0"
-    - rvm: '2.0'
-      env: PUPPET_VERSION="~> 5.3.0"
 
 before_script:
   - puppet --version

--- a/librarian-puppet.gemspec
+++ b/librarian-puppet.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   automatically pulling in modules from the forge and git repositories with
   a single command.'
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.3.0'
 
   s.files = [
     '.gitignore',


### PR DESCRIPTION
The Puppet versions and the Ruby versions are EoL. We should drop support for it. That probably requires a major release. Let's release the current state in https://github.com/voxpupuli/librarian-puppet/pull/81 first.