### PR TITLE
Mark compatible with puppet_forge 3.x

### DIFF
--- a/librarian-puppet.gemspec
+++ b/librarian-puppet.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "librarianp", ">=0.6.3"
   s.add_dependency "rsync"
-  s.add_dependency "puppet_forge", "~> 2.1"
+  s.add_dependency "puppet_forge", ">= 2.1", '< 4'
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
This API isn't breaking for us so it's compatible.