### PR TITLE
Update puppet_forge, which requires Ruby 2.6+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "2.5"
           - "2.6"
           - "2.7"
           - "3.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,20 +11,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "2.6"
           - "2.7"
           - "3.0"
         puppet:
           - "7"
           - "6"
-          - "5"
         exclude:
           - puppet: "6"
             ruby: "3.0"
-          - puppet: "5"
-            ruby: "3.0"
-          - puppet: "5"
-            ruby: "2.7"
     name: Ruby ${{ matrix.ruby }} + Puppet ${{ matrix.puppet }}
     env:
       PUPPET_VERSION: "~> ${{ matrix.puppet }}.0"

--- a/librarian-puppet.gemspec
+++ b/librarian-puppet.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "librarianp", ">=0.6.3"
   s.add_dependency "rsync"
-  s.add_dependency "puppet_forge", ">= 2.1", '< 4'
+  s.add_dependency "puppet_forge", ">= 4.0.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"

--- a/librarian-puppet.gemspec
+++ b/librarian-puppet.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   automatically pulling in modules from the forge and git repositories with
   a single command.'
 
-  s.required_ruby_version = '>= 2.6.0', '< 4'
+  s.required_ruby_version = '>= 2.7.0', '< 4'
 
   s.files = [
     '.gitignore',

--- a/librarian-puppet.gemspec
+++ b/librarian-puppet.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   automatically pulling in modules from the forge and git repositories with
   a single command.'
 
-  s.required_ruby_version = '>= 2.5.0', '< 4'
+  s.required_ruby_version = '>= 2.6.0', '< 4'
 
   s.files = [
     '.gitignore',


### PR DESCRIPTION
This updates the `puppet_forge` dependency to at least 4.0.0 in order to pull in Faraday 2.x and fix the deprecation warnings in #91.

This also means updating the minimum supported Ruby version to 2.6 to match Faraday 2.x which may have consequences that need to be discussed.
