### PR TITLE
support ruby 3.2 by renaming File.exists? to File.exist?

### DIFF
--- a/lib/librarian/puppet/cli.rb
+++ b/lib/librarian/puppet/cli.rb
@@ -23,7 +23,7 @@ module Librarian
       def init
         copy_file environment.specfile_name
 
-        if File.exists? ".gitignore"
+        if File.exist? ".gitignore"
           gitignore = File.read('.gitignore').split("\n")
         else
           gitignore = []

--- a/lib/librarian/puppet/dsl.rb
+++ b/lib/librarian/puppet/dsl.rb
@@ -46,7 +46,7 @@ module Librarian
 
           specfile ||= Proc.new if block_given?
 
-          if specfile.kind_of?(Pathname) and !File.exists?(specfile)
+          if specfile.kind_of?(Pathname) and !File.exist?(specfile)
             debug { "Specfile #{specfile} not found, using defaults" } unless specfile.nil?
             receiver(target).run(specfile, &default_specfile)
           else
@@ -81,7 +81,7 @@ module Librarian
         # implement the 'modulefile' syntax for Puppetfile
         def modulefile
           f = modulefile_path
-          raise Error, "Modulefile file does not exist: #{f}" unless File.exists?(f)
+          raise Error, "Modulefile file does not exist: #{f}" unless File.exist?(f)
           File.read(f).lines.each do |line|
             regexp = /\s*dependency\s+('|")([^'"]+)\1\s*(?:,\s*('|")([^'"]+)\3)?/
             regexp =~ line && mod($2, $4)
@@ -91,10 +91,10 @@ module Librarian
         # implement the 'metadata' syntax for Puppetfile
         def metadata
           f = working_path.join('metadata.json')
-          unless File.exists?(f)
+          unless File.exist?(f)
             msg = "Metadata file does not exist: #{f}"
             # try modulefile, in case we don't have a Puppetfile and we are using the default template
-            if File.exists?(modulefile_path)
+            if File.exist?(modulefile_path)
               modulefile
               return
             else

--- a/lib/librarian/puppet/source/local.rb
+++ b/lib/librarian/puppet/source/local.rb
@@ -139,7 +139,7 @@ module Librarian
         end
 
         def modulefile?
-          File.exists?(modulefile)
+          File.exist?(modulefile)
         end
 
         def metadata
@@ -147,7 +147,7 @@ module Librarian
         end
 
         def metadata?
-          File.exists?(metadata)
+          File.exist?(metadata)
         end
 
         def specfile
@@ -155,7 +155,7 @@ module Librarian
         end
 
         def specfile?
-          File.exists?(specfile)
+          File.exist?(specfile)
         end
 
         def install_perform_step_copy!(found_path, install_path)


### PR DESCRIPTION
`File.exists?` is deprecated and removed in Ruby 3.2. [Here](https://github.com/ruby/ruby/pull/5352) is the commit that removes both `File.exists?` and `Dir.exists?`.

This PR just renames in all places...