### PR TITLE
Default to using API v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,10 +204,8 @@ source specified.  This command writes the complete resolution into
 Librarian-puppet support both v1 and v3 of the Puppet Forge API.
 Specify a specific API version when installing modules:
 
-    $ librarian-puppet install --use-v1-api # this is default; ignored for official Puppet Forge
-    $ librarian-puppet install --no-use-v1-api # use the v3 API; default for official Puppet Forge
-
-Please note that this does not apply for the official Puppet Forge, where v3 is used by default.
+    $ librarian-puppet install --use-v1-api # use the v1 API
+    $ librarian-puppet install --no-use-v1-api # use the v3 API; this is the default
 
 Get an overview of your `Puppetfile.lock` with:
 

--- a/features/install/forge.feature
+++ b/features/install/forge.feature
@@ -263,7 +263,7 @@ Feature: cli/install/forge
   Scenario: Installing from another forge with local reference should not try to download anything from the official forge
     Given a file named "Puppetfile" with:
     """
-    forge "http://127.0.0.1"
+    forge "http://127.0.0.1:8080"
 
     mod 'tester/tester', :path => './tester-tester'
     """
@@ -276,12 +276,12 @@ Feature: cli/install/forge
         "summary": "Just our own test",
         "license": "MIT",
         "dependencies": [
-            { "name": "puppetlabs/inifile" },
-            { "name": "tester/tester_dependency1" }
+            { "name": "puppetlabs/inifile" }
         ]
     }
     """
 
     When I run `librarian-puppet install --verbose`
-    And the output should not contain "forgeapi.puppetlabs.com"
-    And the output should contain "Querying Forge API for module puppetlabs-inifile: http://127.0.0.1/api/v1/releases.json?module=puppetlabs/inifile"
+    And the output should not contain "puppetlabs.com"
+    And the output should not contain "puppet.com"
+    And the output should contain "Resolving puppetlabs-inifile (>= 0) <http://127.0.0.1:8080>"

--- a/lib/librarian/puppet/cli.rb
+++ b/lib/librarian/puppet/cli.rb
@@ -46,7 +46,7 @@ module Librarian
       option "path", :type => :string
       option "destructive", :type => :boolean, :default => false
       option "local", :type => :boolean, :default => false
-      option "use-v1-api", :type => :boolean, :default => true
+      option "use-v1-api", :type => :boolean, :default => false
       def install
 
         ensure!
@@ -73,7 +73,7 @@ module Librarian
       desc "update", "Updates and installs the dependencies you specify."
       option "verbose", :type => :boolean, :default => false
       option "line-numbers", :type => :boolean, :default => false
-      option "use-v1-api", :type => :boolean, :default => true
+      option "use-v1-api", :type => :boolean, :default => false
       def update(*names)
 
         environment.config_db.local['use-v1-api'] = options['use-v1-api'] ? '1' : nil

--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -160,7 +160,7 @@ module Librarian
           unless @repo[name]
             # If we are using the official Forge then use API v3, otherwise use the preferred api 
             # as defined by the CLI option use_v1_api
-            if uri.hostname =~ /\.puppetlabs\.com$/ || !environment.use_v1_api
+            if !environment.use_v1_api
               @repo[name] = RepoV3.new(self, name)
             else
               @repo[name] = RepoV1.new(self, name)


### PR DESCRIPTION
This removes the hack to always use v3 for the official forge by detecting the hostname. That was not taking puppet.com into account, which is now the preferred domain.

This is also much better because there was no way to use a config file to use API v3 by default. This is because librarian-puppet only allows strings in the config and no normalization to false was possible.