### PR TITLE
Drop Modulefile support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,9 +9,7 @@ CLEAN.include('pkg/', 'tmp/')
 CLOBBER.include('Gemfile.lock')
 
 RSpec::Core::RakeTask.new
-Cucumber::Rake::Task.new(:features) do |t|
-  t.cucumber_opts = ['--tags "not @puppet2"']
-end
+Cucumber::Rake::Task.new(:features)
 
 Rake::TestTask.new do |test|
   test.pattern = 'test/**/*_test.rb'

--- a/features/examples/modulefile_syntax/Modulefile
+++ b/features/examples/modulefile_syntax/Modulefile
@@ -1,7 +1,0 @@
-name 'librarian-modulefile_syntax'
-version '0.0.1'
-
-author 'librarian'
-license 'Apache License, Version 2.0'
-
-dependency 'maestrodev/test'

--- a/features/examples/modulefile_syntax/Puppetfile
+++ b/features/examples/modulefile_syntax/Puppetfile
@@ -1,3 +1,0 @@
-forge 'https://forgeapi.puppetlabs.com'
-
-modulefile

--- a/features/examples/modulefile_syntax/manifests/init.pp
+++ b/features/examples/modulefile_syntax/manifests/init.pp
@@ -1,1 +1,0 @@
-class test {}

--- a/features/examples/with_puppetfile_and_modulefile/Modulefile
+++ b/features/examples/with_puppetfile_and_modulefile/Modulefile
@@ -1,7 +1,0 @@
-name 'librarian-with_puppetfile_and_modulefile'
-version '0.0.1'
-
-author 'librarian'
-license 'Apache License, Version 2.0'
-
-dependency 'maestrodev/test'

--- a/features/examples/with_puppetfile_and_modulefile/Puppetfile
+++ b/features/examples/with_puppetfile_and_modulefile/Puppetfile
@@ -1,3 +1,0 @@
-forge 'https://forgeapi.puppetlabs.com'
-
-mod 'maestrodev/test'

--- a/features/examples/with_puppetfile_and_modulefile/manifests/init.pp
+++ b/features/examples/with_puppetfile_and_modulefile/manifests/init.pp
@@ -1,1 +1,0 @@
-class test {}

--- a/features/install.feature
+++ b/features/install.feature
@@ -75,26 +75,6 @@ Feature: cli/install
     Then the exit status should be 0
     And the file "modules/concat/metadata.json" should match /"name": "puppetlabs-concat"/
 
-  @puppet2 @puppet3
-  Scenario: Install a module with Modulefile without version
-    Given a file named "Puppetfile" with:
-    """
-    forge "https://forgeapi.puppetlabs.com"
-
-    mod 'librarian-bad_modulefile', :path => 'bad_modulefile'
-    """
-    And a directory named "bad_modulefile/manifests"
-    And a file named "bad_modulefile/Modulefile" with:
-    """
-    # bad Modulefile
-    """
-    When I run `librarian-puppet install`
-    Then the exit status should be 0
-    And the output should match:
-    """
-    Unable to parse .*/bad_modulefile/Modulefile, ignoring: Missing version
-    """
-
   Scenario: Install a module with the rsync configuration using the --clean flag
     Given a file named "Puppetfile" with:
     """

--- a/features/install/forge.feature
+++ b/features/install/forge.feature
@@ -29,17 +29,6 @@ Feature: cli/install/forge
     When I successfully run `librarian-puppet install`
     And the file "modules/stdlib/metadata.json" should match /"name": "puppetlabs-stdlib"/
 
-  Scenario: Running install with no Puppetfile and Modulefile
-    Given there is no Puppetfile
-    And a file named "Modulefile" with:
-    """
-    name "random name"
-    dependency "puppetlabs/stdlib", "4.1.0"
-    """
-    When I run `librarian-puppet install`
-    Then the exit status should be 0
-    And the file "modules/stdlib/metadata.json" should match /"name": "puppetlabs-stdlib"/
-
   Scenario: Installing a module without forge
     Given a file named "Puppetfile" with:
     """
@@ -182,22 +171,6 @@ Feature: cli/install/forge
     When I successfully run `librarian-puppet install`
     And the file "modules/gitlab/Modulefile" should match /version *'0\.1\.0'/
 
-  Scenario: Source dependencies from Modulefile
-    Given a file named "Puppetfile" with:
-    """
-    forge "https://forgeapi.puppetlabs.com"
-
-    modulefile
-    """
-    And a file named "Modulefile" with:
-    """
-    name "random name"
-    dependency "puppetlabs/postgresql", "4.0.0"
-    """
-    When I run `librarian-puppet install`
-    Then the exit status should be 0
-    And the file "modules/postgresql/metadata.json" should match /"name": "puppetlabs-postgresql"/
-
   Scenario: Source dependencies from metadata.json
     Given a file named "Puppetfile" with:
     """
@@ -218,22 +191,6 @@ Feature: cli/install/forge
     }
     """
     When I successfully run `librarian-puppet install`
-    And the file "modules/postgresql/metadata.json" should match /"name": "puppetlabs-postgresql"/
-
-  Scenario: Source dependencies from Modulefile using dash instead of slash
-    Given a file named "Puppetfile" with:
-    """
-    forge "https://forgeapi.puppetlabs.com"
-
-    modulefile
-    """
-    And a file named "Modulefile" with:
-    """
-    name "random name"
-    dependency "puppetlabs-postgresql", "4.0.0"
-    """
-    When I run `librarian-puppet install`
-    Then the exit status should be 0
     And the file "modules/postgresql/metadata.json" should match /"name": "puppetlabs-postgresql"/
 
   Scenario: Installing a module with duplicated dependencies

--- a/features/install/git.feature
+++ b/features/install/git.feature
@@ -84,16 +84,6 @@ Feature: cli/install/git
     And the file "modules/with_puppetfile/metadata.json" should match /"name": "librarian-with_puppetfile"/
     And the file "modules/test/metadata.json" should match /"name": "librarian-test"/
 
-  Scenario: Install a module with dependencies specified in a Puppetfile and Modulefile
-    Given a file named "Puppetfile" with:
-    """
-    mod 'librarian/with_puppetfile', :git => 'https://github.com/voxpupuli/librarian-puppet.git', :path => 'features/examples/with_puppetfile_and_modulefile'
-    """
-    When I run `librarian-puppet install`
-    Then the exit status should be 0
-    And the file "modules/with_puppetfile/Modulefile" should match /name *'librarian-with_puppetfile_and_modulefile'/
-    And the file "modules/test/Modulefile" should match /name *'maestrodev-test'/
-
   Scenario: Install a module with dependencies specified in a Puppetfile and metadata.json
     Given a file named "Puppetfile" with:
     """
@@ -103,7 +93,7 @@ Feature: cli/install/git
     And the file "modules/with_puppetfile/metadata.json" should match /"name": "librarian-with_puppetfile_and_metadata_json"/
     And the file "modules/test/metadata.json" should match /"name": "maestrodev-test"/
 
-  Scenario: Running install with no Modulefile nor metadata.json
+  Scenario: Running install without metadata.json
     Given a file named "Puppetfile" with:
     """
     forge "https://forgeapi.puppetlabs.com"
@@ -120,16 +110,6 @@ Feature: cli/install/git
     mod 'puppetlabs/sqlite', :git => 'https://github.com/puppetlabs/puppetlabs-sqlite.git', :ref => '84a0a6'
     """
     When I successfully run `librarian-puppet install`
-
-  Scenario: Install a module using modulefile syntax
-    Given a file named "Puppetfile" with:
-    """
-    mod 'librarian/modulefile_syntax', :git => 'https://github.com/voxpupuli/librarian-puppet.git', :path => 'features/examples/modulefile_syntax'
-    """
-    When I run `librarian-puppet install`
-    Then the exit status should be 0
-    And the file "modules/modulefile_syntax/Modulefile" should match /name *'librarian-modulefile_syntax'/
-    And the file "modules/test/Modulefile" should match /name *'maestrodev-test'/
 
   Scenario: Install a module using metadata syntax
     Given a file named "Puppetfile" with:

--- a/features/install/path.feature
+++ b/features/install/path.feature
@@ -20,16 +20,6 @@ Feature: cli/install/path
     And the file "modules/test/metadata.json" should match /"name": "librarian-test"/
     And a file named "modules/stdlib/metadata.json" should exist
 
-  Scenario: Install a module with dependencies specified in a Puppetfile and Modulefile
-    Given a file named "Puppetfile" with:
-    """
-    mod 'librarian/with_puppetfile', :path => '../../features/examples/with_puppetfile_and_modulefile'
-    """
-    When I run `librarian-puppet install`
-    Then the exit status should be 0
-    And the file "modules/with_puppetfile/Modulefile" should match /name *'librarian-with_puppetfile_and_modulefile'/
-    And the file "modules/test/Modulefile" should match /name *'maestrodev-test'/
-
   Scenario: Install a module with dependencies specified in a Puppetfile and metadata.json
     Given a file named "Puppetfile" with:
     """

--- a/features/update.feature
+++ b/features/update.feature
@@ -30,29 +30,6 @@ Feature: cli/update
     And the file "modules/stdlib/Modulefile" should match /name *'puppetlabs-stdlib'/
     And the file "modules/stdlib/Modulefile" should match /version *'3\.1\.1'/
 
-  Scenario: Updating a module with no Puppetfile and with Modulefile
-    Given a file named "Modulefile" with:
-    """
-    name "random name"
-    dependency "puppetlabs/stdlib", "3.1.x"
-    """
-    And a file named "Puppetfile.lock" with:
-    """
-    FORGE
-      remote: https://forgeapi.puppetlabs.com
-      specs:
-        puppetlabs/stdlib (3.1.0)
-
-    DEPENDENCIES
-      puppetlabs/stdlib (~> 3.0)
-    """
-    When I run `librarian-puppet update puppetlabs/stdlib`
-    Then the exit status should be 0
-    And the file "Puppetfile" should not exist
-    And the file "Puppetfile.lock" should match /puppetlabs.stdlib \(3\.1\.1\)/
-    And the file "modules/stdlib/Modulefile" should match /name *'puppetlabs-stdlib'/
-    And the file "modules/stdlib/Modulefile" should match /version *'3\.1\.1'/
-
   Scenario: Updating a module
     Given a file named "Puppetfile" with:
     """

--- a/lib/librarian/puppet/action/install.rb
+++ b/lib/librarian/puppet/action/install.rb
@@ -17,7 +17,7 @@ module Librarian
         end
 
         def check_specfile
-          # don't fail if Puppetfile doesn't exist as we'll use the Modulefile or metadata.json
+          # don't fail if Puppetfile doesn't exist as we'll use metadata.json
         end
 
       end

--- a/lib/librarian/puppet/dsl.rb
+++ b/lib/librarian/puppet/dsl.rb
@@ -78,28 +78,11 @@ module Librarian
           super
         end
 
-        # implement the 'modulefile' syntax for Puppetfile
-        def modulefile
-          f = modulefile_path
-          raise Error, "Modulefile file does not exist: #{f}" unless File.exist?(f)
-          File.read(f).lines.each do |line|
-            regexp = /\s*dependency\s+('|")([^'"]+)\1\s*(?:,\s*('|")([^'"]+)\3)?/
-            regexp =~ line && mod($2, $4)
-          end
-        end
-
         # implement the 'metadata' syntax for Puppetfile
         def metadata
           f = working_path.join('metadata.json')
           unless File.exist?(f)
-            msg = "Metadata file does not exist: #{f}"
-            # try modulefile, in case we don't have a Puppetfile and we are using the default template
-            if File.exist?(modulefile_path)
-              modulefile
-              return
-            else
-              raise Error, msg
-            end
+            raise Error, "Metadata file does not exist: #{f}"
           end
           begin
             json = JSON.parse(File.read(f))
@@ -110,12 +93,6 @@ module Librarian
           dependencyList.each do |d|
             mod(d['name'], d['version_requirement'])
           end
-        end
-
-        private
-
-        def modulefile_path
-          working_path.join('Modulefile')
         end
       end
     end

--- a/lib/librarian/puppet/templates/Puppetfile
+++ b/lib/librarian/puppet/templates/Puppetfile
@@ -6,9 +6,6 @@ forge "https://forgeapi.puppetlabs.com"
 # use dependencies defined in metadata.json
 metadata
 
-# use dependencies defined in Modulefile
-# modulefile
-
 # A module from the Puppet Forge
 # mod 'puppetlabs-stdlib'
 


### PR DESCRIPTION
Puppet >= 4 does not support Modulefile and Puppet < 4 is long EOL.

This leaves a lot of tests referencing Modulefile because they install ancient versions. They should be updated.