### PR TITLE
Switch from forgeapi.puppetlabs.com->forgeapi.puppet.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ If no Puppetfile is present, `librarian-puppet` will download all the dependenci
 listed in your `metadata.json` or `Modulefile` from the Puppet Forge,
 as if the Puppetfile contained
 
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     metadata
 
 
 ### Example Puppetfile
 
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs-razor'
     mod 'puppetlabs-ntp', "0.0.3"
@@ -92,7 +92,7 @@ When fetching a module all dependencies specified in its
 
 ### Puppetfile Breakdown
 
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
 This declares that we want to use the official Puppet Labs Forge as our default
 source when pulling down modules.  If you run your own local forge, you may

--- a/features/examples/duplicated_dependencies_transitive/Puppetfile
+++ b/features/examples/duplicated_dependencies_transitive/Puppetfile
@@ -1,4 +1,4 @@
-forge 'https://forgeapi.puppetlabs.com'
+forge 'https://forgeapi.puppet.com'
 
 metadata
 

--- a/features/examples/metadata_syntax/Puppetfile
+++ b/features/examples/metadata_syntax/Puppetfile
@@ -1,3 +1,3 @@
-forge 'https://forgeapi.puppetlabs.com'
+forge 'https://forgeapi.puppet.com'
 
 metadata

--- a/features/examples/with_puppetfile_and_metadata_json/Puppetfile
+++ b/features/examples/with_puppetfile_and_metadata_json/Puppetfile
@@ -1,3 +1,3 @@
-forge 'https://forgeapi.puppetlabs.com'
+forge 'https://forgeapi.puppet.com'
 
 mod 'maestrodev/test'

--- a/features/install.feature
+++ b/features/install.feature
@@ -19,7 +19,7 @@ Feature: cli/install
   Scenario: Install a module transitive dependency from git and forge should be deterministic
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/stdlib', :git => 'https://github.com/puppetlabs/puppetlabs-stdlib.git', :ref => '4.6.0'
     mod 'librarian/test', :git => 'https://github.com/voxpupuli/librarian-puppet.git', :path => 'features/examples/test'
@@ -31,7 +31,7 @@ Feature: cli/install
   Scenario: Install duplicated dependencies from git and forge, last one wins
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     metadata
     mod 'puppetlabs-stdlib', :git => 'https://github.com/puppetlabs/puppetlabs-stdlib.git', :ref => '4.6.0'
@@ -55,7 +55,7 @@ Feature: cli/install
   Scenario: Installing two modules with same name and using exclusions
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'librarian-duplicated_dependencies', :path => '../../features/examples/duplicated_dependencies'
     exclusion 'ripienaar-concat'
@@ -67,7 +67,7 @@ Feature: cli/install
   Scenario: Installing two modules with same name and using exclusions, apply transitively
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'librarian-duplicated_dependencies_transitive', :path => '../../features/examples/duplicated_dependencies_transitive'
     """
@@ -78,7 +78,7 @@ Feature: cli/install
   Scenario: Install a module with the rsync configuration using the --clean flag
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'maestrodev/test'
     """
@@ -99,7 +99,7 @@ Feature: cli/install
   Scenario: Install a module with the rsync configuration using the --destructive flag
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'maestrodev/test'
     """
@@ -121,7 +121,7 @@ Feature: cli/install
   Scenario: Install a module with the rsync configuration
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'maestrodev/test'
     """

--- a/features/install/forge.feature
+++ b/features/install/forge.feature
@@ -4,7 +4,7 @@ Feature: cli/install/forge
   Scenario: Installing a module and its dependencies
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/ntp'
     """
@@ -41,7 +41,7 @@ Feature: cli/install/forge
   Scenario: Installing an exact version of a module
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/apt', '0.0.4'
     """
@@ -57,7 +57,7 @@ Feature: cli/install/forge
   Scenario: Installing a module in a path with spaces
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
     mod 'puppetlabs/stdlib', '4.1.0'
     """
     When PENDING I run `librarian-puppet install`
@@ -67,7 +67,7 @@ Feature: cli/install/forge
   Scenario: Installing a module with invalid versions in the forge
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/apache', '7.0.0' # compatible with stdlib 8
     mod 'puppetlabs/postgresql', '7.4.0' # incompatible with stdlib 8
@@ -85,7 +85,7 @@ Feature: cli/install/forge
   Scenario: Installing a module with several constraints
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/apt', '>=1.0.0', '<1.0.1'
     """
@@ -98,7 +98,7 @@ Feature: cli/install/forge
     Given a directory named "puppet"
     And a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/ntp', '3.0.3'
     """
@@ -112,7 +112,7 @@ Feature: cli/install/forge
   Scenario: Handle range version numbers
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/postgresql', '7.4.1'
     mod 'puppetlabs/apt', '< 8.4.0'
@@ -125,7 +125,7 @@ Feature: cli/install/forge
 
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/postgresql', :git => 'https://github.com/puppetlabs/puppet-postgresql', :ref => 'v7.5.0'
     """
@@ -138,7 +138,7 @@ Feature: cli/install/forge
   Scenario: Installing a module that does not exist
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/xxxxx'
     """
@@ -146,13 +146,13 @@ Feature: cli/install/forge
     Then the exit status should be 1
     And the output should match:
       """
-      Unable to find module 'puppetlabs-xxxxx' on https://forgeapi.puppetlabs.com
+      Unable to find module 'puppetlabs-xxxxx' on https://forgeapi.puppet.com
       """
 
   Scenario: Install a module with conflicts
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/apache', '0.6.0'
     mod 'puppetlabs/stdlib', '<2.2.1'
@@ -164,7 +164,7 @@ Feature: cli/install/forge
   Scenario: Install a module from the Forge with dependencies without version
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'sbadia/gitlab', '0.1.0'
     """
@@ -174,7 +174,7 @@ Feature: cli/install/forge
   Scenario: Source dependencies from metadata.json
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     metadata
     """
@@ -196,7 +196,7 @@ Feature: cli/install/forge
   Scenario: Installing a module with duplicated dependencies
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'pdxcat/collectd', '2.1.0'
     """
@@ -207,7 +207,7 @@ Feature: cli/install/forge
   Scenario: Installing two modules with same name, alphabetical order wins
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'theforeman-dhcp', '4.0.0'
     mod 'puppet-dhcp', '2.0.0'

--- a/features/install/git.feature
+++ b/features/install/git.feature
@@ -4,7 +4,7 @@ Feature: cli/install/git
   Scenario: Installing a module from git
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/apache',
         :git => 'https://github.com/puppetlabs/puppetlabs-apache.git', :ref => '1.4.0'
@@ -32,7 +32,7 @@ Feature: cli/install/git
   Scenario: Installing a module with invalid versions in git
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod "apache",
       :git => "https://github.com/puppetlabs/puppetlabs-apache.git", :ref => "1.4.0"
@@ -44,7 +44,7 @@ Feature: cli/install/git
   Scenario: Switching a module from forge to git
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/postgresql', '7.4.1'
     """
@@ -54,7 +54,7 @@ Feature: cli/install/git
     And the file "modules/stdlib/metadata.json" should match /"name": "puppetlabs-stdlib"/
     When I overwrite "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/postgresql',
       :git => 'https://github.com/puppetlabs/puppetlabs-postgresql.git', :ref => 'v7.5.0'
@@ -96,7 +96,7 @@ Feature: cli/install/git
   Scenario: Running install without metadata.json
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/stdlib', :git => 'https://github.com/puppetlabs/puppetlabs-stdlib.git', :ref => '4.6.0'
     """
@@ -105,7 +105,7 @@ Feature: cli/install/git
   Scenario: Running install with metadata.json without dependencies
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/sqlite', :git => 'https://github.com/puppetlabs/puppetlabs-sqlite.git', :ref => '84a0a6'
     """
@@ -123,7 +123,7 @@ Feature: cli/install/git
   Scenario: Install a module from git and using path
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'librarian-test', :git => 'https://github.com/voxpupuli/librarian-puppet.git', :path => 'features/examples/test'
     """
@@ -134,7 +134,7 @@ Feature: cli/install/git
   Scenario: Install a module from git without version
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'test', :git => 'https://github.com/voxpupuli/librarian-puppet.git', :path => 'features/examples/dependency_without_version'
     """

--- a/features/install/github_tarball.feature
+++ b/features/install/github_tarball.feature
@@ -5,7 +5,7 @@ Feature: cli/install/github_tarball
   Scenario: Installing a module from github tarballs
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/apache', '0.6.0', :github_tarball => 'puppetlabs/puppetlabs-apache'
     mod 'puppetlabs/stdlib', '2.3.0', :github_tarball => 'puppetlabs/puppetlabs-stdlib'

--- a/features/install/path.feature
+++ b/features/install/path.feature
@@ -32,7 +32,7 @@ Feature: cli/install/path
   Scenario: Install a module from path without version
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'test', :path => '../../features/examples/dependency_without_version'
     """

--- a/features/outdated.feature
+++ b/features/outdated.feature
@@ -4,14 +4,14 @@ Feature: cli/outdated
   Scenario: Running outdated with forge modules
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/stdlib', '>=3.1.x'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: https://forgeapi.puppetlabs.com
+      remote: https://forgeapi.puppet.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -27,14 +27,14 @@ Feature: cli/outdated
   Scenario: Running outdated with git modules
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'test', :git => 'https://github.com/voxpupuli/librarian-puppet.git', :path => 'features/examples/test'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: https://forgeapi.puppetlabs.com
+      remote: https://forgeapi.puppet.com
       specs:
         puppetlabs/stdlib (3.1.0)
 

--- a/features/package.feature
+++ b/features/package.feature
@@ -4,7 +4,7 @@ Feature: cli/package
   Scenario: Packaging a forge module
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/apt', '1.4.0'
     mod 'puppetlabs/stdlib', '4.1.0'
@@ -19,7 +19,7 @@ Feature: cli/package
   Scenario: Packaging a git module
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/apt', '1.5.0', :git => 'https://github.com/puppetlabs/puppetlabs-apt.git', :ref => '1.5.0'
     mod 'puppetlabs/stdlib', '4.1.0'
@@ -35,7 +35,7 @@ Feature: cli/package
   Scenario: Packaging a github tarball module
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/apt', '1.4.0', :github_tarball => 'puppetlabs/puppetlabs-apt'
     mod 'puppetlabs/stdlib', '4.1.0'

--- a/features/update.feature
+++ b/features/update.feature
@@ -17,7 +17,7 @@ Feature: cli/update
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: https://forgeapi.puppetlabs.com
+      remote: https://forgeapi.puppet.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -33,14 +33,14 @@ Feature: cli/update
   Scenario: Updating a module
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/stdlib', '3.1.x'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: https://forgeapi.puppetlabs.com
+      remote: https://forgeapi.puppet.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -55,14 +55,14 @@ Feature: cli/update
   Scenario: Updating a module using organization/module
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/stdlib', '3.1.x'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: https://forgeapi.puppetlabs.com
+      remote: https://forgeapi.puppet.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -77,7 +77,7 @@ Feature: cli/update
   Scenario: Updating a module from git with a branch ref
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod "theforeman-dns",
       :git => "https://github.com/theforeman/puppet-dns.git", :ref => "4.1-stable"
@@ -85,7 +85,7 @@ Feature: cli/update
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: https://forgeapi.puppetlabs.com
+      remote: https://forgeapi.puppet.com
       specs:
         puppetlabs-concat (2.2.1)
           puppetlabs-stdlib (>= 4.2.0, < 5.0.0)
@@ -111,7 +111,7 @@ Feature: cli/update
   Scenario: Updating a module with invalid versions in git
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod "apache",
       :git => "https://github.com/puppetlabs/puppetlabs-apache.git", :ref => "0.5.0-rc1"
@@ -119,7 +119,7 @@ Feature: cli/update
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: https://forgeapi.puppetlabs.com
+      remote: https://forgeapi.puppet.com
       specs:
         puppetlabs/firewall (0.0.4)
         puppetlabs/stdlib (3.2.0)
@@ -144,14 +144,14 @@ Feature: cli/update
   Scenario: Updating a module that is not in the Puppetfile
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'puppetlabs/stdlib', '3.1.x'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: https://forgeapi.puppetlabs.com
+      remote: https://forgeapi.puppet.com
       specs:
         puppetlabs/stdlib (3.1.0)
 
@@ -165,14 +165,14 @@ Feature: cli/update
   Scenario: Updating a module to a .10 release to ensure versions are correctly ordered
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'maestrodev/test'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: https://forgeapi.puppetlabs.com
+      remote: https://forgeapi.puppet.com
       specs:
         maestrodev/test (1.0.2)
 
@@ -187,14 +187,14 @@ Feature: cli/update
   Scenario: Updating a forge module with the rsync configuration
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod 'maestrodev/test'
     """
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: https://forgeapi.puppetlabs.com
+      remote: https://forgeapi.puppet.com
       specs:
         maestrodev/test (1.0.2)
 
@@ -218,7 +218,7 @@ Feature: cli/update
   Scenario: Updating a git module with the rsync configuration
     Given a file named "Puppetfile" with:
     """
-    forge "https://forgeapi.puppetlabs.com"
+    forge "https://forgeapi.puppet.com"
 
     mod "theforeman-dns",
       :git => "https://github.com/theforeman/puppet-dns.git", :ref => "4.1-stable"
@@ -226,7 +226,7 @@ Feature: cli/update
     And a file named "Puppetfile.lock" with:
     """
     FORGE
-      remote: https://forgeapi.puppetlabs.com
+      remote: https://forgeapi.puppet.com
       specs:
         puppetlabs-concat (2.2.1)
           puppetlabs-stdlib (>= 4.2.0, < 5.0.0)

--- a/lib/librarian/puppet/dsl.rb
+++ b/lib/librarian/puppet/dsl.rb
@@ -7,7 +7,7 @@ module Librarian
   module Puppet
     class Dsl < Librarian::Dsl
 
-      FORGE_URL = "https://forgeapi.puppetlabs.com"
+      FORGE_URL = "https://forgeapi.puppet.com"
 
       dependency :mod
 

--- a/lib/librarian/puppet/templates/Puppetfile
+++ b/lib/librarian/puppet/templates/Puppetfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 #^syntax detection
 
-forge "https://forgeapi.puppetlabs.com"
+forge "https://forgeapi.puppet.com"
 
 # use dependencies defined in metadata.json
 metadata

--- a/spec/action/resolve_spec.rb
+++ b/spec/action/resolve_spec.rb
@@ -20,7 +20,7 @@ describe 'Librarian::Puppet::Action::Resolve' do
       resolution = environment.lock.manifests.map { |m| {:name => m.name, :version => m.version.to_s, :source => m.source.to_s} }
       expect(resolution.size).to eq(1)
       expect(resolution.first[:name]).to eq("puppetlabs-stdlib")
-      expect(resolution.first[:source]).to eq("https://forgeapi.puppetlabs.com")
+      expect(resolution.first[:source]).to eq("https://forgeapi.puppet.com")
       expect(resolution.first[:version]).to match(/\d+\.\d+\.\d+/)
     end
 

--- a/spec/source/forge_spec.rb
+++ b/spec/source/forge_spec.rb
@@ -7,7 +7,7 @@ include Librarian::Puppet::Source
 describe Forge do
 
   let(:environment) { Librarian::Puppet::Environment.new }
-  let(:uri) { "https://forgeapi.puppetlabs.com" }
+  let(:uri) { "https://forgeapi.puppet.com" }
   subject { Forge.new(environment, uri) }
 
   describe "#manifests" do


### PR DESCRIPTION
Puppet updated the URL a long time ago. forgeapi.puppetlabs.com is the old one, forgeapi.puppet.com the new one.