### PR TITLE
Fix missing action when installing with --strip-dot-git

### DIFF
--- a/features/install/git.feature
+++ b/features/install/git.feature
@@ -153,3 +153,13 @@ Feature: cli/install/git
     """
     When I successfully run `librarian-puppet install`
     And the output should contain "Dependency 'puppetlabs-stdlib' duplicated for module, merging"
+
+  Scenario: Installing a module from git with the --strip-dot-git flag
+    Given a file named "Puppetfile" with:
+    """
+    mod 'puppetlabs-stdlib',
+      :git => 'https://github.com/puppetlabs/puppetlabs-stdlib.git',
+      :ref => 'main'
+    """
+    When I successfully run `librarian-puppet install --strip-dot-git` for up to 60 seconds
+    And a directory named "modules/stdlib/.git" should not exist

--- a/lib/librarian/puppet/source/git.rb
+++ b/lib/librarian/puppet/source/git.rb
@@ -37,6 +37,10 @@ module Librarian
             raise Error, "Could not checkout #{uri}#{" at #{sha}" unless sha.nil?}: #{e}"
           end
 
+          if strip_dot_git? and repository.git?
+            repository.path.join('.git').rmtree
+          end
+
           cache_in_vendor(repository.path) if environment.vendor?
         end
 
@@ -52,6 +56,10 @@ module Librarian
 
         def vendor_cached?
           vendor_tgz.exist?
+        end
+
+        def strip_dot_git?
+          environment.config_db.local["install.strip-dot-git"] == '1'
         end
 
         def vendor_checkout!


### PR DESCRIPTION
Hello,

For legacy projects, we want to use the `--strip-dot-git` option when running the `librarian-puppet install` command. This option is listed in the output of `librarian-puppet help install`.

We intend to use this option to remove the `.git` directory from cloned modules so that we can commit them without having to manage Git submodules.

Since this option is documented in the help, I took the liberty of creating a pull request to implement this behavior when the option is enabled.

To get the tests working, I had to pin the version of `minitest` to `< 5.19.0` because the newer version introduced a naming change that causes issues with `mocha`.

Would it be possible to release a new version with this fix?