### PR TITLE
concurrent-ruby: Require 1.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,18 +23,11 @@ jobs:
         puppet:
           - "8"
           - "7"
-          - "6"
         exclude:
           - puppet: "8"
             ruby: "2.7"
           - puppet: "8"
             ruby: "3.0"
-          - puppet: "6"
-            ruby: "3.0"
-          - puppet: "6"
-            ruby: "3.1"
-          - puppet: "6"
-            ruby: "3.2"
     name: Ruby ${{ matrix.ruby }} + Puppet ${{ matrix.puppet }}
     env:
       PUPPET_VERSION: "~> ${{ matrix.puppet }}.0"

--- a/librarian-puppet.gemspec
+++ b/librarian-puppet.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", "~> 5"
   s.add_development_dependency "mocha", '~> 2.7'
   s.add_development_dependency "simplecov", ">= 0.9.0"
-  s.add_development_dependency "concurrent-ruby", "< 1.2"
+  s.add_development_dependency "concurrent-ruby", '~> 1.3'
 end

--- a/librarian-puppet.gemspec
+++ b/librarian-puppet.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
-  s.add_development_dependency "cucumber", "<9.0.0"
+  s.add_development_dependency "cucumber", '~> 9.2'
   s.add_development_dependency "aruba", ">= 1.0", "< 3"
   s.add_development_dependency "puppet", ENV["PUPPET_VERSION"]
   s.add_development_dependency "minitest", "~> 5"


### PR DESCRIPTION
In the past we had to pin to an older version due to a bug in Puppet. It used an internal API that got removed. That's fixed in recent Puppet versions.

contains:
* https://github.com/voxpupuli/librarian-puppet/pull/132
* https://github.com/voxpupuli/librarian-puppet/pull/133